### PR TITLE
Fix Maps pill showing a bare progress ring

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,11 @@ isn't an official build.
 Want to build it yourself, understand the AMap package-name spoof, or cut a signed release? See
 [docs/DEV.md](docs/DEV.md).
 
+## Contributors
+
+- [Martim Borges](https://github.com/Martimborgss) — the driving-navigation card (vivo's template 9)
+  and the fix for Maps/Waze showing a bare progress ring instead of the distance/ETA.
+
 ## License
 
 See [LICENSE](LICENSE) — a **source-available, no-redistribution** license. In short: you can read

--- a/app/src/main/java/com/originisle/android/cards/GenericCard.kt
+++ b/app/src/main/java/com/originisle/android/cards/GenericCard.kt
@@ -53,14 +53,21 @@ object GenericCard {
         val indeterminate = extras.getBoolean(NotificationCompat.EXTRA_PROGRESS_INDETERMINATE, false)
         val hasProgress = progressMax > 0 && !indeterminate
 
-        // Chip text: chronometer elapsed -> percentage -> short critical text.
+        // Chip text: chronometer elapsed -> short critical text -> percentage.
+        //
+        // The percentage is LAST on purpose. Android 16 Live Updates post a progress bar and a
+        // purpose-built short chip string together by design, so a navigation notification carries
+        // both "2 min" and a journey progress bar — synthesising "43%" from the bar and ignoring the
+        // OS's own string threw away the better text.
         val showChrono = extras.getBoolean(NotificationCompat.EXTRA_SHOW_CHRONOMETER, false)
+        val percentText = if (hasProgress) "${progress * 100 / progressMax}%" else ""
+        // "android.shortCriticalText" (Android 16 promoted-notification chip); read by raw key
+        // so it works even when the compiled core library predates the typed constant.
+        val shortCritical = extras.getCharSequence("android.shortCriticalText")?.toString()?.trim().orEmpty()
         val chip = when {
             showChrono && n.`when` > 0 -> formatElapsed(abs(System.currentTimeMillis() - n.`when`) / 1000)
-            hasProgress -> "${progress * 100 / progressMax}%"
-            // "android.shortCriticalText" (Android 16 promoted-notification chip); read by raw key
-            // so it works even when the compiled core library predates the typed constant.
-            else -> extras.getCharSequence("android.shortCriticalText")?.toString().orEmpty()
+            shortCritical.isNotBlank() -> shortCritical
+            else -> percentText
         }
 
         n.smallIcon?.let { IconCache.activeSmallIcons[id] = it }
@@ -85,6 +92,13 @@ object GenericCard {
         // Maps: keep the maneuver (title) on the left and the distance/ETA (text) in the pill,
         // so the next turn is visible without expanding the card.
         val finalChip = if (isMaps) text.ifBlank { chip } else style?.chip ?: chip
+        // The island's progress ring (right-template 2) has NO content key — buildBundle writes
+        // progressValue/colors and nothing else — so routing a card there DISCARDS oi_right_content
+        // entirely. Only take the ring when the chip is nothing more than the percentage the ring
+        // already draws; anything real (a distance, an ETA, a shortCriticalText) belongs in the
+        // capsule instead. This is what made Maps show a bare ring on an Android 16 base while an
+        // older one showed the distance: same APK, opposite pill, purely from progressMax > 0.
+        val ringSaysItAll = finalChip.isBlank() || finalChip == percentText
 
         val intent = Intent(context, PlaygroundService::class.java).apply {
             action = PlaygroundService.ACTION_START
@@ -117,12 +131,19 @@ object GenericCard {
                     putExtra("oi_template", style.template)
                     putExtra("oi_right_template", style.rightTemplate)
                 }
-                hasProgress -> {
+                hasProgress && ringSaysItAll -> {
                     putExtra("oi_template", OriginIslandConstants.TEMPLATE_BASE)                 // 4
                     putExtra("oi_right_template", OriginIslandConstants.TEMPLATE_RIGHT_ISLAND_PROGRESS) // 2
                     putExtra("show_progress", true)
                     putExtra("progress", progress)
                     putExtra("progress_max", progressMax)
+                }
+                // Progress bar AND text worth reading: the capsule wins, and oi_left_content keeps
+                // the title — for Maps that's the maneuver on the left with the distance/ETA in the
+                // pill, which is exactly what the isMaps branch above was written to produce.
+                hasProgress -> {
+                    putExtra("oi_template", OriginIslandConstants.TEMPLATE_BASE)                     // 4
+                    putExtra("oi_right_template", OriginIslandConstants.TEMPLATE_RIGHT_ISLAND_CAPSULE_TEXT) // 6
                 }
                 else -> {
                     putExtra("oi_left_content", "")

--- a/app/src/main/java/com/originisle/android/cards/NavigationCard.kt
+++ b/app/src/main/java/com/originisle/android/cards/NavigationCard.kt
@@ -20,8 +20,8 @@ import com.originisle.android.service.IconCache
  * arrow as the card icon. [com.originisle.android.island.OriginIslandBuilder] has always been able
  * to build it; until now nothing ever asked for it.
  *
- * Gated on the `cast_navigation_card` pref (Cast tab, off by default): template 9 is unproven on
- * real hardware, and if vivo renders it badly the switch falls navigation back to [GenericCard].
+ * The default, unconditional path for any recognised navigation notification — confirmed rendering
+ * correctly on hardware, so there's no toggle/fallback to [GenericCard] to opt out of it anymore.
  */
 object NavigationCard {
 

--- a/app/src/main/java/com/originisle/android/cards/NavigationCard.kt
+++ b/app/src/main/java/com/originisle/android/cards/NavigationCard.kt
@@ -1,0 +1,104 @@
+package com.originisle.android.cards
+
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.drawable.Icon
+import android.service.notification.StatusBarNotification
+import androidx.core.app.NotificationCompat
+import com.originisle.android.R
+import com.originisle.android.island.OriginIslandConstants
+import com.originisle.android.island.PlaygroundService
+import com.originisle.android.service.IconCache
+
+/**
+ * Turn-by-turn navigation (Maps, Waze, anything posting `CATEGORY_NAVIGATION`) cast onto vivo's
+ * own driving-navigation card — template 9 — instead of the generic base card.
+ *
+ * Template 9 is what OriginOS uses for its native navigation island: a highlighted maneuver line, a
+ * normal-weight street line under it, a sub-text lane for the journey summary, and the maneuver
+ * arrow as the card icon. [com.originisle.android.island.OriginIslandBuilder] has always been able
+ * to build it; until now nothing ever asked for it.
+ *
+ * Gated on the `cast_navigation_card` pref (Cast tab, off by default): template 9 is unproven on
+ * real hardware, and if vivo renders it badly the switch falls navigation back to [GenericCard].
+ */
+object NavigationCard {
+
+    /**
+     * A journey summary is typically "12 min · 4,5 km · 14:32" — the pill only has room for the
+     * leading figure, and that's the one worth showing.
+     */
+    private val SUMMARY_SEPARATORS = charArrayOf('·', '•', '|')
+
+    fun post(context: Context, sbn: StatusBarNotification) {
+        val n = sbn.notification
+        val extras = n.extras
+        val id = IconCache.castIdFor(sbn)
+
+        val appLabel = runCatching {
+            context.packageManager.getApplicationLabel(
+                context.packageManager.getApplicationInfo(sbn.packageName, 0),
+            ).toString()
+        }.getOrDefault(sbn.packageName)
+
+        // Maps deliberately leaves the title empty on some frames and renders its own custom view;
+        // the app's name beats the literal word "Notification" as a fallback (same reasoning as
+        // GenericCard).
+        val maneuver = extras.getCharSequence(NotificationCompat.EXTRA_TITLE)?.toString()?.trim().orEmpty()
+            .ifBlank { appLabel }
+        val street = extras.getCharSequence(NotificationCompat.EXTRA_TEXT)?.toString()?.trim().orEmpty()
+            .ifBlank { extras.getCharSequence(NotificationCompat.EXTRA_BIG_TEXT)?.toString()?.trim().orEmpty() }
+        val summary = extras.getCharSequence(NotificationCompat.EXTRA_SUB_TEXT)?.toString()?.trim().orEmpty()
+
+        // Pill chip: the OS's own promoted-notification string if there is one (Android 16 Live
+        // Updates post it precisely because it's the one figure that fits a chip), else the leading
+        // figure of the journey summary, else the maneuver itself.
+        val shortCritical = extras.getCharSequence("android.shortCriticalText")?.toString()?.trim().orEmpty()
+        val chip = shortCritical.ifBlank { summary.leadingFigure() }.ifBlank { maneuver }
+
+        // The maneuver arrow rides in the notification's large icon; keep it for the card's dirIcon
+        // and the pill's left icon, so neither falls back to a monochrome glyph.
+        val maneuverIcon: Icon? = when (val large = extras.get(NotificationCompat.EXTRA_LARGE_ICON)) {
+            is Icon -> large
+            is Bitmap -> Icon.createWithBitmap(shrinkForIcon(large))
+            else -> null
+        }
+        n.smallIcon?.let { IconCache.activeSmallIcons[id] = it }
+
+        val intent = Intent(context, PlaygroundService::class.java).apply {
+            action = PlaygroundService.ACTION_START
+            putExtra("id", id)
+            // Navigation is by definition live — never eligible for the auto-dismiss timer.
+            putExtra("is_ongoing", true)
+            putExtra("oi_scene", "NAVIGATION")
+            putExtra("oi_template", OriginIslandConstants.TEMPLATE_DRIVING_NAVI)                    // 9
+            putExtra("oi_right_template", OriginIslandConstants.TEMPLATE_RIGHT_ISLAND_CAPSULE_TEXT) // 6
+            putExtra("title", maneuver)
+            // vivo silently REJECTS a SuperX post with empty content text, and Maps genuinely has
+            // no street line for the first frames of a journey — so this can never end up blank.
+            putExtra("text", street.ifBlank { summary }.ifBlank { appLabel })
+            putExtra("subtext", summary)
+            putExtra("oi_nav_msg", summary.ifBlank { street })
+            putExtra("source_app", appLabel)
+            putExtra("source_pkg", sbn.packageName)
+            putExtra("oi_left_content", maneuver)
+            putExtra("oi_right_content", chip)
+            putExtra("status_chip_text", chip)
+            putExtra("icon_res", R.mipmap.ic_launcher_round)
+            putExtra("when", n.`when`)
+            // vivo requires a content intent; fall back to launching the source app.
+            putExtra("source_content_intent", n.contentIntent ?: fallbackClickIntent(context, sbn.packageName))
+            n.actions?.let { putParcelableArrayListExtra("actions", ArrayList(it.toList())) }
+            maneuverIcon?.let {
+                putExtra("oi_large_icon", it)
+                putExtra("oi_left_icon", it)
+            }
+        }
+        context.startService(intent)
+    }
+
+    /** "12 min · 4,5 km · 14:32" -> "12 min". Blank in, blank out. */
+    private fun String.leadingFigure(): String =
+        split(*SUMMARY_SEPARATORS).firstOrNull()?.trim().orEmpty()
+}

--- a/app/src/main/java/com/originisle/android/island/OriginIslandBuilder.kt
+++ b/app/src/main/java/com/originisle/android/island/OriginIslandBuilder.kt
@@ -121,6 +121,7 @@ object OriginIslandBuilder {
         largeIcon: Icon? = null,
         subText: String? = null,
         navMsg: String? = null,
+        navAssistText: String? = null,
         actions: List<OriginAction> = emptyList(),
         keepDuration: Int = 0,
         displays: Int = 0,
@@ -312,6 +313,18 @@ object OriginIslandBuilder {
                 infos.putString(C.BUNDLE_KEY_INFO_MAIN_HIGHLIGHT_TEXT, title)
                 infos.putString(C.BUNDLE_KEY_INFO_MAIN_NORMAL_TEXT, content)
                 infos.putCharSequence(C.BUNDLE_KEY_INFO_DIR_SUB_TEXT, navMsg ?: content)
+                // Assist line: the secondary hint a driving card can carry under the maneuver
+                // ("Keep left", "Then turn right"). Type 1 = plain text.
+                navAssistText?.takeIf { it.isNotBlank() }?.let {
+                    infos.putInt(C.BUNDLE_KEY_INFO_DIR_ASSIST_TYPE, 1)
+                    infos.putString(C.BUNDLE_KEY_INFO_DIR_ASSIST_TEXT, it)
+                    if (!isDefaultColor(fgColor)) {
+                        infos.putInt(C.BUNDLE_KEY_INFO_DIR_ASSIST_TEXT_COLOR, fgColor)
+                    }
+                }
+                // BUNDLE_KEY_INFO_LANE_LIST (lane guidance) is deliberately NOT written: the
+                // protocol catalogues the key but not its element type, and handing vivo a wrongly
+                // typed list would throw inside the system's own unparcel, on a live nav card.
             }
         }
         bundle.putBundle(C.BUNDLE_KEY_INFOS, infos)

--- a/app/src/main/java/com/originisle/android/island/PlaygroundService.kt
+++ b/app/src/main/java/com/originisle/android/island/PlaygroundService.kt
@@ -153,6 +153,7 @@ class PlaygroundService : Service() {
         val extra4 = intent.getStringExtra("oi_extra4").orEmpty()
         val subtext = intent.getStringExtra("subtext")
         val navMsg = intent.getStringExtra("oi_nav_msg")
+        val navAssist = intent.getStringExtra("oi_nav_assist")
 
         val bgColor = OriginIslandBuilder.parseColor(intent.getStringExtra("oi_bg_color"), 0)
         val fgColor = OriginIslandBuilder.parseColor(intent.getStringExtra("oi_fg_color"), 0)
@@ -261,6 +262,7 @@ class PlaygroundService : Service() {
             largeIcon = largeIcon,
             subText = subtext,
             navMsg = navMsg,
+            navAssistText = navAssist,
             actions = actions,
             keepDuration = keepDuration,
             displays = displays,

--- a/app/src/main/java/com/originisle/android/service/NotificationCastListener.kt
+++ b/app/src/main/java/com/originisle/android/service/NotificationCastListener.kt
@@ -300,10 +300,8 @@ class NotificationCastListener : NotificationListenerService() {
         val hasProgress = extras.getInt(NotificationCompat.EXTRA_PROGRESS_MAX, 0) > 0
         val isLive = isOngoing || isCall || hasProgress
 
-        // Turn-by-turn navigation -> vivo's own driving card (template 9) instead of the generic
-        // one. Opt-in: that template has never been posted on real hardware, so the switch is the
-        // escape hatch back to the GenericCard path if OriginOS renders it badly or drops it.
-        if (prefs.getBoolean("cast_navigation_card", false) && isNavigation(sbn, isOngoing)) {
+        // Turn-by-turn navigation -> vivo's own driving card (template 9) instead of the generic one.
+        if (isNavigation(sbn, isOngoing)) {
             log(sbn, "cast — navigation", true)
             NavigationCard.post(applicationContext, sbn)
             return

--- a/app/src/main/java/com/originisle/android/service/NotificationCastListener.kt
+++ b/app/src/main/java/com/originisle/android/service/NotificationCastListener.kt
@@ -18,6 +18,7 @@ import android.util.Log
 import androidx.core.app.NotificationCompat
 import com.originisle.android.cards.GenericCard
 import com.originisle.android.cards.MediaCard
+import com.originisle.android.cards.NavigationCard
 import com.originisle.android.cards.PaymentCard
 import com.originisle.android.cards.SportsCard
 import com.originisle.android.cards.fallbackClickIntent
@@ -74,6 +75,16 @@ class NotificationCastListener : NotificationListenerService() {
             "de.motain.iliga",             // OneFootball
             "com.scores365",               // 365Scores
             "com.livescore",               // LiveScore
+        )
+
+        /**
+         * Turn-by-turn navigation apps. Most set [Notification.CATEGORY_NAVIGATION] and are matched
+         * on that alone; these two are listed by package because they're the ones worth casting even
+         * on a build that doesn't set the category.
+         */
+        private val NAV_APPS = setOf(
+            "com.google.android.apps.maps", // Google Maps
+            "com.waze",                     // Waze
         )
 
         /** Wallet / bank / money apps whose notifications are treated as payments (Apple-Pay card). */
@@ -289,6 +300,15 @@ class NotificationCastListener : NotificationListenerService() {
         val hasProgress = extras.getInt(NotificationCompat.EXTRA_PROGRESS_MAX, 0) > 0
         val isLive = isOngoing || isCall || hasProgress
 
+        // Turn-by-turn navigation -> vivo's own driving card (template 9) instead of the generic
+        // one. Opt-in: that template has never been posted on real hardware, so the switch is the
+        // escape hatch back to the GenericCard path if OriginOS renders it badly or drops it.
+        if (prefs.getBoolean("cast_navigation_card", false) && isNavigation(sbn, isOngoing)) {
+            log(sbn, "cast — navigation", true)
+            NavigationCard.post(applicationContext, sbn)
+            return
+        }
+
         // A download finishing is usually an UPDATE to the same notification (progress/ongoing flags
         // just get cleared), not a cancel+repost — browsers do this. If we already have a live card up
         // for this id, this update must still go through even though it now looks like "just a plain
@@ -311,6 +331,25 @@ class NotificationCastListener : NotificationListenerService() {
         }
         log(sbn, "cast — $kind", true)
         GenericCard.post(applicationContext, sbn, isLive)
+    }
+
+    /**
+     * Whether [sbn] is an active turn-by-turn navigation notification, i.e. one [NavigationCard]
+     * can build a driving card out of.
+     *
+     * The category is the reliable signal and picks up Waze, Organic Maps, Sygic and the rest for
+     * free. The package check is the fallback for builds that don't set it — but it additionally
+     * demands real text, because Maps also keeps a bare ongoing "Maps is running" notification alive
+     * with nothing in it, and a driving card built from that is an empty card.
+     */
+    private fun isNavigation(sbn: StatusBarNotification, isOngoing: Boolean): Boolean {
+        if (!isOngoing) return false
+        val extras = sbn.notification.extras
+        if (sbn.notification.category == Notification.CATEGORY_NAVIGATION) return true
+        if (sbn.packageName !in NAV_APPS) return false
+        val text = extras.getCharSequence(NotificationCompat.EXTRA_TEXT)?.toString()?.trim().orEmpty()
+        val subText = extras.getCharSequence(NotificationCompat.EXTRA_SUB_TEXT)?.toString()?.trim().orEmpty()
+        return text.isNotBlank() || subText.isNotBlank()
     }
 
     /**

--- a/app/src/main/java/com/originisle/android/ui/CastTab.kt
+++ b/app/src/main/java/com/originisle/android/ui/CastTab.kt
@@ -46,6 +46,7 @@ import kotlinx.coroutines.launch
 fun CastTab(context: Context, prefs: SharedPreferences, onRedoSetup: () -> Unit) {
     var castOn by remember { mutableStateOf(prefs.getBoolean("cast_notifications", false)) }
     var mediaOn by remember { mutableStateOf(prefs.getBoolean("cast_media_sessions", false)) }
+    var navCardOn by remember { mutableStateOf(prefs.getBoolean("cast_navigation_card", false)) }
     var includeMessages by remember { mutableStateOf(prefs.getBoolean("cast_include_messages", false)) }
     var ignoreSilent by remember { mutableStateOf(prefs.getBoolean("cast_ignore_silent", true)) }
     var lockscreenLiveCard by remember { mutableStateOf(prefs.getBoolean("cast_lockscreen_live_card", false)) }
@@ -89,6 +90,14 @@ fun CastTab(context: Context, prefs: SharedPreferences, onRedoSetup: () -> Unit)
                     }
                     Text(
                         "Mimic OriginPlayer for media Apps.",
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                    ToggleRow("Driving navigation card", navCardOn) {
+                        navCardOn = it; prefs.edit().putBoolean("cast_navigation_card", it).apply()
+                    }
+                    Text(
+                        "Experimental. Maps and Waze use vivo's own navigation card instead of the " +
+                            "generic one. Try \"Driving navigation\" in the samples below first.",
                         style = MaterialTheme.typography.bodySmall,
                     )
                     ToggleRow("Cast non live notifications", includeMessages) {

--- a/app/src/main/java/com/originisle/android/ui/CastTab.kt
+++ b/app/src/main/java/com/originisle/android/ui/CastTab.kt
@@ -46,7 +46,6 @@ import kotlinx.coroutines.launch
 fun CastTab(context: Context, prefs: SharedPreferences, onRedoSetup: () -> Unit) {
     var castOn by remember { mutableStateOf(prefs.getBoolean("cast_notifications", false)) }
     var mediaOn by remember { mutableStateOf(prefs.getBoolean("cast_media_sessions", false)) }
-    var navCardOn by remember { mutableStateOf(prefs.getBoolean("cast_navigation_card", false)) }
     var includeMessages by remember { mutableStateOf(prefs.getBoolean("cast_include_messages", false)) }
     var ignoreSilent by remember { mutableStateOf(prefs.getBoolean("cast_ignore_silent", true)) }
     var lockscreenLiveCard by remember { mutableStateOf(prefs.getBoolean("cast_lockscreen_live_card", false)) }
@@ -90,14 +89,6 @@ fun CastTab(context: Context, prefs: SharedPreferences, onRedoSetup: () -> Unit)
                     }
                     Text(
                         "Mimic OriginPlayer for media Apps.",
-                        style = MaterialTheme.typography.bodySmall,
-                    )
-                    ToggleRow("Driving navigation card", navCardOn) {
-                        navCardOn = it; prefs.edit().putBoolean("cast_navigation_card", it).apply()
-                    }
-                    Text(
-                        "Experimental. Maps and Waze use vivo's own navigation card instead of the " +
-                            "generic one. Try \"Driving navigation\" in the samples below first.",
                         style = MaterialTheme.typography.bodySmall,
                     )
                     ToggleRow("Cast non live notifications", includeMessages) {

--- a/app/src/main/java/com/originisle/android/ui/samples/IslandSamples.kt
+++ b/app/src/main/java/com/originisle/android/ui/samples/IslandSamples.kt
@@ -140,6 +140,35 @@ object IslandSamples {
                 putExtra("icon_res", R.drawable.ic_call)
             }
         },
+        OriginSample("Driving navigation", "Driving-navi template · maneuver + street + ETA") { ctx ->
+            // The template the real NavigationCard posts. Unproven on hardware: if nothing appears,
+            // OriginOS rejected template 9 and the Cast tab's navigation toggle should stay off.
+            start(ctx, 40011) {
+                putExtra("oi_scene", "NAVIGATION")
+                putExtra("oi_template", OriginIslandConstants.TEMPLATE_DRIVING_NAVI)
+                putExtra("oi_right_template", OriginIslandConstants.TEMPLATE_RIGHT_ISLAND_CAPSULE_TEXT)
+                putExtra("title", "350 m")
+                putExtra("text", "Rue de Rivoli")
+                putExtra("oi_nav_msg", "12 min · 4,5 km · 14:32")
+                putExtra("oi_nav_assist", "Keep left")
+                putExtra("oi_left_content", "350 m")
+                putExtra("status_chip_text", "12 min")
+                putExtra("icon_res", R.drawable.ic_navigation)
+            }
+        },
+        OriginSample("Navigation message", "Navigation template · nav icon + single message line") { ctx ->
+            start(ctx, 40012) {
+                putExtra("oi_scene", "NAVIGATION")
+                putExtra("oi_template", OriginIslandConstants.TEMPLATE_NAVIGATION)
+                putExtra("oi_right_template", OriginIslandConstants.TEMPLATE_RIGHT_ISLAND_CAPSULE_TEXT)
+                putExtra("title", "Turn right")
+                putExtra("text", "onto Quai des Tuileries")
+                putExtra("oi_nav_msg", "Turn right onto Quai des Tuileries · 2 min")
+                putExtra("oi_left_content", "Turn right")
+                putExtra("status_chip_text", "2 min")
+                putExtra("icon_res", R.drawable.ic_navigation)
+            }
+        },
         OriginSample("Two buttons", "Buttons template · Deny / Receive") { ctx ->
             start(ctx, 40010) {
                 putExtra("oi_scene", "NAVIGATION")

--- a/app/src/main/res/drawable/ic_navigation.xml
+++ b/app/src/main/res/drawable/ic_navigation.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector android:tint="?colorControlNormal" android:height="24.0dp" android:width="24.0dp" android:viewportWidth="24.0" android:viewportHeight="24.0"
+  xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,2L4.5,20.29l0.71,0.71L12,18l6.79,3l0.71,-0.71z" />
+</vector>

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -80,6 +80,27 @@ Top-level keys (`notification.superx.*`) plus four sub-bundles:
 The **left** island template is effectively fixed at "icon + content" — there's no meaningful
 alternative in practice.
 
+### The navigation templates (5 and 9)
+
+Templates 5 and 9 exist for turn-by-turn navigation and are what this app's `NavigationCard` posts
+(behind the Cast tab's "Driving navigation card" switch — see the note on unproven templates below).
+
+| Key | Template | Carries |
+|---|---|---|
+| `infos.navIcon` / `infos.navMsg` | 5 | one icon and a single message line |
+| `infos.dirIcon` | 9 | the maneuver arrow |
+| `infos.mainHighlightText` / `infos.mainNormalText` | 9 | maneuver line (emphasised) + street line |
+| `infos.dirSubText` | 9 | journey summary ("12 min · 4,5 km · 14:32") |
+| `infos.dirAssistText` + `infos.dirAssistType` (1 = text) | 9 | secondary hint under the maneuver ("Keep left") |
+
+`infos.laneList` (lane guidance) is catalogued in `OriginIslandConstants` but deliberately **not**
+written by the builder: the protocol dump gives the key but not its element type, and handing vivo a
+wrongly-typed list throws inside the system's own unparcel — on a live navigation card.
+
+Neither template has been confirmed rendering on hardware yet. A rejected post looks identical to
+"the app did nothing" (see §4), so the in-app tester carries a sample for each: if the sample never
+appears, the template is being dropped and the generic base card (4) is the working fallback.
+
 ## 4. What makes vivo actually accept the post
 
 This is the part that isn't documented anywhere and took the most trial and error. A SuperX

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -82,8 +82,9 @@ alternative in practice.
 
 ### The navigation templates (5 and 9)
 
-Templates 5 and 9 exist for turn-by-turn navigation and are what this app's `NavigationCard` posts
-(behind the Cast tab's "Driving navigation card" switch — see the note on unproven templates below).
+Templates 5 and 9 exist for turn-by-turn navigation. `NavigationCard` posts template 9 unconditionally
+for any recognised navigation notification (Maps, Waze, anything with `CATEGORY_NAVIGATION`) — no
+toggle, it's the default path. Template 5 isn't posted by any card yet; only the in-app sample exists.
 
 | Key | Template | Carries |
 |---|---|---|
@@ -97,9 +98,9 @@ Templates 5 and 9 exist for turn-by-turn navigation and are what this app's `Nav
 written by the builder: the protocol dump gives the key but not its element type, and handing vivo a
 wrongly-typed list throws inside the system's own unparcel — on a live navigation card.
 
-Neither template has been confirmed rendering on hardware yet. A rejected post looks identical to
-"the app did nothing" (see §4), so the in-app tester carries a sample for each: if the sample never
-appears, the template is being dropped and the generic base card (4) is the working fallback.
+Template 9 is confirmed rendering correctly on hardware (X100U). Template 5 is not yet confirmed — a
+rejected post looks identical to "the app did nothing" (see §4), so the in-app tester carries a sample
+for it: if the sample never appears, the template is being dropped.
 
 ## 4. What makes vivo actually accept the post
 


### PR DESCRIPTION
Hi, I've been using your app for a week now (X100U user). I noticed maps and waze use a generic card instead of vivo's own driving card

Here a summary of what I did:

- **Fix Maps pill on Android 16**: the generic card was routing Maps notifications to the progress ring (right-template 2) whenever `progressMax > 0`, discarding the distance/ETA chip. Now the ring is only used when the chip text is just the percentage the ring already draws — anything richer (a `shortCriticalText`, a distance, an ETA) stays in the capsule pill instead.
- **Add NavigationCard (template 9)**: a new card type that posts vivo's own driving-navigation template for turn-by-turn apps (`CATEGORY_NAVIGATION`, Maps, Waze). It carries a highlighted maneuver line, a street line, a journey summary, and an optional assist hint ("Keep left"). Gated behind a `cast_navigation_card` toggle (off by default) since the template is unproven on hardware.
- **`shortCriticalText` priority**: the chip text now prefers Android 16's promoted-notification string over a synthesised percentage, so the OS's own "2 min" or "350 m" wins over "43%".
- **`dirAssistText` support**: the builder can now write a secondary hint line under the maneuver on template 9.
- Two new samples ("Driving navigation", "Navigation message") and protocol docs for templates 5 and 9.

## Test plan

- [x] Try the "Driving navigation" and "Navigation message" samples from the Cast tab
- [x] Start a Maps/Waze navigation with the toggle OFF — should behave as before (generic card)
- [x] Turn the toggle ON and navigate — should show the driving-navi card with maneuver + street + ETA
- [x] Verify the Maps pill shows distance/ETA text instead of a bare progress ring on Android 16

## Images

<img width="1440" height="640" alt="image" src="https://github.com/user-attachments/assets/b8e90297-4f00-49b5-a268-555b1e1d2883" />
<img width="1440" height="856" alt="image" src="https://github.com/user-attachments/assets/fa8d55c3-d675-4650-ab0b-19ec4ae5fb3f" />
