### PR TITLE
Fix notification listener dying permanently on swipe-away

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,9 +30,22 @@
 
         <!-- Posts / updates / ends OriginIsland SuperX cards. Special-use FGS so it can
              keep re-posting a live card (e.g. a ticking football score). -->
+        <!--
+            stopWithTask=false + START_STICKY are what get casting back after the app is swiped off
+            recents. OriginOS kills the whole app on that swipe (a separate :island process does NOT
+            survive it either — measured), so the recovery can't come from staying alive; it comes
+            from the system RESTARTING this foreground service afterwards, which respawns the
+            process and rebinds the notification listener with it.
+
+            That restart is gated on vivo's "Associated startup" toggle, which controls whether the
+            system may start this app at all. With it off, nothing recovers — not START_STICKY, not
+            the onTaskRemoved alarm, not the accessibility service — and only a reboot fixes it.
+            Onboarding calls that out explicitly; see OnboardingScreen.
+        -->
         <service
             android:name=".island.PlaygroundService"
-            android:foregroundServiceType="specialUse">
+            android:foregroundServiceType="specialUse"
+            android:stopWithTask="false">
             <property
                 android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
                 android:value="OriginIsland live update service" />

--- a/app/src/main/java/com/originisle/android/MainActivity.kt
+++ b/app/src/main/java/com/originisle/android/MainActivity.kt
@@ -1,9 +1,7 @@
 package com.originisle.android
 
-import android.content.ComponentName
 import android.content.Context
 import android.os.Bundle
-import android.service.notification.NotificationListenerService
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Column
@@ -46,15 +44,21 @@ class MainActivity : ComponentActivity() {
         intent?.getIntExtra("autofire_sample", -1)?.takeIf { it >= 0 }?.let {
             IslandSamples.all.getOrNull(it)?.post(this)
         }
+        setContent { OriginIsleTheme { Screen() } }
+    }
+
+    /**
+     * Heal a listener that died with the process (OriginOS kills it on swipe-away) every time the
+     * app comes to the foreground, not just on a cold start — otherwise a resume of an
+     * already-running task silently skips the recovery. [NotificationCastListener.forceRebind] is a
+     * no-op while the listener is connected, so this is cheap on the normal path.
+     */
+    override fun onResume() {
+        super.onResume()
         if (getSharedPreferences(PREFS_NAME, MODE_PRIVATE).getBoolean("cast_notifications", false)) {
             PlaygroundService.keepAlive(this)
-            runCatching {
-                NotificationListenerService.requestRebind(
-                    ComponentName(this, NotificationCastListener::class.java),
-                )
-            }
+            NotificationCastListener.forceRebind(this)
         }
-        setContent { OriginIsleTheme { Screen() } }
     }
 }
 

--- a/app/src/main/java/com/originisle/android/island/PlaygroundService.kt
+++ b/app/src/main/java/com/originisle/android/island/PlaygroundService.kt
@@ -1,24 +1,22 @@
 package com.originisle.android.island
 
+import android.app.AlarmManager
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.Service
-import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.graphics.drawable.Icon
 import android.os.Handler
 import android.os.IBinder
 import android.os.Looper
-import android.provider.Settings
 import android.util.Log
 import android.widget.RemoteViews
 import androidx.core.app.NotificationCompat
 import com.originisle.android.R
 import com.originisle.android.service.IconCache
-import com.originisle.android.service.KeepAliveAccessibilityService
 import com.originisle.android.ui.PREFS_NAME
 import java.util.concurrent.ConcurrentHashMap
 
@@ -56,6 +54,9 @@ class PlaygroundService : Service() {
 
         const val ORIGIN_CHANNEL_ID = "originisle_island_hi"
         const val FGS_ID = 9999
+
+        /** PendingIntent request code for the [onTaskRemoved] restart alarm. */
+        private const val RESTART_REQUEST = 7001
     }
 
     private lateinit var notificationManager: NotificationManager
@@ -97,18 +98,55 @@ class PlaygroundService : Service() {
         return START_STICKY
     }
 
+    /**
+     * Swiping the task away on OriginOS kills the whole process — the notification listener with it.
+     * START_STICKY is not enough on its own there (the service simply never came back), so re-arm
+     * two ways: make sure the FGS is up, and leave an alarm behind that restarts this service a
+     * second later if the process dies anyway.
+     *
+     * The alarm survives the kill because a swipe is a plain process kill, not a force-stop —
+     * verified with `dumpsys package`, which still reports `stopped=false` afterwards. (A real
+     * force-stop sets that flag and cancels alarms, and nothing an app does can escape it.)
+     * [PendingIntent.getForegroundService] is what the alarm fires; starting an FGS from the
+     * background is allowed here because the app is on the battery-optimisation allowlist, which
+     * onboarding already asks for.
+     */
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        super.onTaskRemoved(rootIntent)
+        runCatching { ensureForeground() }
+        runCatching {
+            val restart = PendingIntent.getForegroundService(
+                this,
+                RESTART_REQUEST,
+                Intent(this, PlaygroundService::class.java).setAction(ACTION_KEEPALIVE),
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            )
+            getSystemService(AlarmManager::class.java)?.set(
+                AlarmManager.RTC_WAKEUP, System.currentTimeMillis() + 1000L, restart,
+            )
+        }
+    }
+
     private fun ensureForeground() {
         if (isForegroundActive) return
-        // If the keep-alive AccessibilityService is enabled, it anchors the process for us — so we
-        // DON'T start a foreground service, and skipping it removes the status-bar icon that OriginOS
-        // force-shows for any FGS.
+        // The FGS now starts UNCONDITIONALLY. It used to be skipped whenever the keep-alive
+        // AccessibilityService was enabled, on the theory that accessibility alone anchors the
+        // process — but that premise is wrong, and it was the reason casting died for good on
+        // swipe-away. Measured on an X200 Pro (OriginOS): swiping the task away kills the process,
+        // and `dumpsys accessibility` then reports
         //
-        // IMPORTANT: we only SKIP starting the FGS here; we must NEVER tear down an already-running
-        // FGS the instant accessibility connects. Doing that left the process with no anchor for a
-        // moment, OriginOS killed it, and the kill disconnected (disabled) the accessibility service.
-        // So the FGS just isn't (re)started once accessibility is on — the icon clears on the next
-        // process start, and the process always keeps an anchor.
-        if (isKeepAliveAccessibilityEnabled()) return
+        //     Enabled services:{{…/KeepAliveAccessibilityService}}
+        //     Crashed services:{{…/KeepAliveAccessibilityService}}
+        //
+        // i.e. AccessibilityManagerService sees the binding die, marks the service CRASHED, and
+        // never rebinds it. It stays "enabled" in Settings.Secure while being completely dead, so
+        // the process had no anchor at all, nothing restarted it, and only a reboot (which rebinds
+        // every enabled accessibility service from scratch) brought casting back.
+        //
+        // The status-bar icon this skip was avoiding is already handled a different way: CHANNEL_ID
+        // is created at IMPORTANCE_NONE (blocked), which suppresses the FGS notification outright —
+        // see createNotificationChannel. So running the FGS costs nothing visually and buys the one
+        // anchor the system actually honours across task removal.
         createNotificationChannel(CHANNEL_ID)
         val n = NotificationCompat.Builder(this, CHANNEL_ID)
             .setContentTitle("Origin Isle")
@@ -435,15 +473,6 @@ class PlaygroundService : Service() {
             stopSelf()
         }
         if (hadScenes) mainHandler.postDelayed({ finish() }, 350L) else finish()
-    }
-
-    /** True when the user has enabled the keep-alive AccessibilityService (no FGS icon needed then). */
-    private fun isKeepAliveAccessibilityEnabled(): Boolean {
-        val flat = Settings.Secure.getString(
-            contentResolver, Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES,
-        ) ?: return false
-        val target = ComponentName(this, KeepAliveAccessibilityService::class.java)
-        return flat.split(':').any { ComponentName.unflattenFromString(it) == target }
     }
 
     private fun createNotificationChannel(channelId: String) {

--- a/app/src/main/java/com/originisle/android/service/KeepAliveAccessibilityService.kt
+++ b/app/src/main/java/com/originisle/android/service/KeepAliveAccessibilityService.kt
@@ -1,8 +1,6 @@
 package com.originisle.android.service
 
 import android.accessibilityservice.AccessibilityService
-import android.content.ComponentName
-import android.service.notification.NotificationListenerService
 import android.view.accessibility.AccessibilityEvent
 import com.originisle.android.island.OriginIslandBuilder
 
@@ -21,11 +19,10 @@ class KeepAliveAccessibilityService : AccessibilityService() {
 
     override fun onServiceConnected() {
         super.onServiceConnected()
-        runCatching {
-            NotificationListenerService.requestRebind(
-                ComponentName(this, NotificationCastListener::class.java),
-            )
-        }
+        // This fires when the system (re)starts our process, which is exactly the moment the
+        // notification listener needs recovering after a swipe-away kill. A plain requestRebind is
+        // a no-op in that case — see [NotificationCastListener.forceRebind].
+        runCatching { NotificationCastListener.forceRebind(this) }
         runCatching { OriginIslandBuilder.grantScenes(this) }
     }
 

--- a/app/src/main/java/com/originisle/android/service/NotificationCastListener.kt
+++ b/app/src/main/java/com/originisle/android/service/NotificationCastListener.kt
@@ -3,8 +3,10 @@ package com.originisle.android.service
 import android.app.Notification
 import android.app.NotificationManager
 import android.content.ComponentName
+import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
+import android.content.pm.PackageManager
 import android.graphics.drawable.Icon
 import android.media.session.MediaController
 import android.media.session.MediaSession
@@ -16,6 +18,7 @@ import android.service.notification.NotificationListenerService.Ranking
 import android.service.notification.StatusBarNotification
 import android.util.Log
 import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
 import com.originisle.android.cards.GenericCard
 import com.originisle.android.cards.MediaCard
 import com.originisle.android.cards.NavigationCard
@@ -43,6 +46,9 @@ import java.util.concurrent.ConcurrentHashMap
  */
 class NotificationCastListener : NotificationListenerService() {
 
+    /** Outcome of [forceRebind], so callers can tell the user something truthful. */
+    enum class RebindResult { REBINDING, ALREADY_CONNECTED, NO_ACCESS, FAILED }
+
     companion object {
         /** The bound listener instance, or null if the service isn't connected. */
         @Volatile
@@ -54,8 +60,74 @@ class NotificationCastListener : NotificationListenerService() {
         @Volatile
         var lastEventAt: Long = 0L
 
+        /**
+         * Force the system to re-bind this listener after the process was killed (OriginOS kills it
+         * on swipe-away), and report whether a rebind could even be attempted.
+         *
+         * [NotificationListenerService.requestRebind] alone is NOT enough, and this is the whole
+         * reason the Reconnect button did nothing. It lands in `NotificationManagerService`
+         * -> `ManagedServices.setComponentState(component, userId, enabled = true)`, which starts
+         * with an early return when the requested state already matches the tracked one:
+         *
+         *     boolean previous = !mSnoozing...contains(component);
+         *     if (previous == enabled) return;
+         *
+         * A component is only in that "snoozing" set after an explicit [requestUnbind]. When the
+         * listener instead dies with a force-stopped process, it was never snoozed — so the system
+         * still believes it is bound, `previous == enabled` holds, and `requestRebind` returns
+         * having done literally nothing. No amount of tapping the button changes that; only a
+         * reboot (which rebuilds the bindings from scratch) did.
+         *
+         * Toggling the component's enabled state is what actually moves the system: each
+         * `setComponentEnabledSetting` fires `ACTION_PACKAGE_CHANGED`, whose receiver in
+         * `NotificationManagerService` calls `mListeners.onPackagesChanged(removing = false, …)`
+         * -> `rebindServices()`, and that rebinds every approved-but-unbound listener. The grant
+         * itself lives in `Settings.Secure.enabled_notification_listeners` keyed by component name
+         * and is untouched by this, so access is not lost. `DONT_KILL_APP` keeps our own process
+         * (and the island's foreground service) up across the toggle.
+         */
+        fun forceRebind(context: Context): RebindResult {
+            val component = ComponentName(context.applicationContext, NotificationCastListener::class.java)
+            if (!NotificationManagerCompat.getEnabledListenerPackages(context)
+                    .contains(context.packageName)
+            ) {
+                return RebindResult.NO_ACCESS
+            }
+            if (instance != null) return RebindResult.ALREADY_CONNECTED
+            // The rebind is asynchronous (it waits on a package broadcast), so a burst of callers —
+            // onResume firing repeatedly while the listener is still down — must not keep tearing
+            // down a binding that is already on its way up.
+            val now = System.currentTimeMillis()
+            if (now - lastRebindAt < REBIND_THROTTLE_MS) return RebindResult.REBINDING
+            lastRebindAt = now
+
+            val pm = context.applicationContext.packageManager
+            val toggled = runCatching {
+                pm.setComponentEnabledSetting(
+                    component,
+                    PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+                    PackageManager.DONT_KILL_APP,
+                )
+                pm.setComponentEnabledSetting(
+                    component,
+                    PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+                    PackageManager.DONT_KILL_APP,
+                )
+            }.isSuccess
+            // Belt and braces: after the toggle the component IS considered unbound, so this call is
+            // no longer a no-op and can shortcut the wait for the package broadcast to land.
+            runCatching { requestRebind(component) }
+            return if (toggled) RebindResult.REBINDING else RebindResult.FAILED
+        }
+
         private const val PREFS = "experimental_prefs"
         private const val TAG = "NotificationCast"
+
+        /** Minimum gap between component toggles in [forceRebind]. */
+        private const val REBIND_THROTTLE_MS = 10_000L
+
+        @Volatile
+        private var lastRebindAt = 0L
 
         /** Framework/system packages whose notifications are noise on the island. */
         private val SYSTEM_PKGS = setOf(
@@ -195,6 +267,11 @@ class NotificationCastListener : NotificationListenerService() {
         if (instance === this) instance = null
         connectedAt = 0L
         pollHandler.removeCallbacks(pollRunnable)
+        // A system-initiated unbind DOES leave the component snoozed, so here — unlike from the
+        // Reconnect button — a plain requestRebind is the documented, working way back (see
+        // [forceRebind] for why it is a no-op in the process-kill case). Self-heals the transient
+        // disconnects without the user having to open the app at all.
+        runCatching { requestRebind(ComponentName(this, NotificationCastListener::class.java)) }
     }
 
     /**

--- a/app/src/main/java/com/originisle/android/ui/CastTab.kt
+++ b/app/src/main/java/com/originisle/android/ui/CastTab.kt
@@ -270,15 +270,13 @@ private fun recastAll(context: Context) {
     PlaygroundService.keepAlive(context)
     val listener = NotificationCastListener.instance
     if (listener == null) {
-        runCatching {
-            android.service.notification.NotificationListenerService.requestRebind(
-                android.content.ComponentName(context, NotificationCastListener::class.java),
-            )
+        val message = when (NotificationCastListener.forceRebind(context)) {
+            NotificationCastListener.RebindResult.NO_ACCESS ->
+                "Notification access isn't granted — turn it on in Settings, then tap again."
+            else ->
+                "Listener not connected — reconnecting now. Give it a few seconds, then tap again."
         }
-        android.widget.Toast.makeText(
-            context, "Listener not connected yet — grant notification access, reboot app, then tap again.",
-            android.widget.Toast.LENGTH_LONG,
-        ).show()
+        android.widget.Toast.makeText(context, message, android.widget.Toast.LENGTH_LONG).show()
         return
     }
     val count = listener.recastAll()

--- a/app/src/main/java/com/originisle/android/ui/LogTab.kt
+++ b/app/src/main/java/com/originisle/android/ui/LogTab.kt
@@ -122,13 +122,18 @@ fun LogTab(context: Context) {
 }
 
 private fun reconnectListener(context: Context) {
-    runCatching {
-        android.service.notification.NotificationListenerService.requestRebind(
-            android.content.ComponentName(context, NotificationCastListener::class.java),
-        )
-    }
     PlaygroundService.keepAlive(context)
-    android.widget.Toast.makeText(context, "Rebinding listener…", android.widget.Toast.LENGTH_SHORT).show()
+    val message = when (NotificationCastListener.forceRebind(context)) {
+        NotificationCastListener.RebindResult.REBINDING ->
+            "Rebinding listener… give it a few seconds."
+        NotificationCastListener.RebindResult.ALREADY_CONNECTED ->
+            "Listener is already connected."
+        NotificationCastListener.RebindResult.NO_ACCESS ->
+            "Notification access isn't granted — turn it on in Settings first."
+        NotificationCastListener.RebindResult.FAILED ->
+            "Couldn't rebind. Reboot, or toggle notification access off and on."
+    }
+    android.widget.Toast.makeText(context, message, android.widget.Toast.LENGTH_LONG).show()
 }
 
 private fun clockText(ts: Long): String =

--- a/app/src/main/java/com/originisle/android/ui/OnboardingScreen.kt
+++ b/app/src/main/java/com/originisle/android/ui/OnboardingScreen.kt
@@ -40,6 +40,11 @@ import androidx.lifecycle.LifecycleEventObserver
  * First-run gate: walks through every authorization the app needs before letting the user into the
  * main tabs. Only notification access is mandatory to continue; the rest are strongly recommended
  * (battery, keep-alive, auto-start) and can be granted later from the Cast tab's "Redo setup" button.
+ *
+ * The auto-start row matters more than its "recommended" status suggests: OriginOS's "Associated
+ * startup" toggle governs whether the SYSTEM is allowed to start this app. With it off, nothing can
+ * bring casting back after the app is swiped off recents — not START_STICKY, not the restart alarm,
+ * not the accessibility service — and only a reboot recovers. Measured on an X200 Pro.
  * Every row re-checks its status when the user returns from Settings (via [Lifecycle.Event.ON_RESUME]).
  */
 @Composable
@@ -123,8 +128,11 @@ fun OnboardingScreen(context: Context, prefs: SharedPreferences, onDone: () -> U
             }
             item {
                 OnboardingRow(
-                    title = "OriginOS auto-start",
-                    description = "vivo can't be checked automatically.",
+                    title = "Auto-start + Associated startup",
+                    description = "Turn BOTH on, especially \"Associated startup\". Without it OriginOS " +
+                        "forbids the system from restarting Origin Isle, so closing the app from recents " +
+                        "kills casting until you reboot the phone. vivo doesn't let apps check this, so " +
+                        "it's on you to confirm it's on.",
                     granted = autoStartAck,
                     mandatory = false,
                 ) {


### PR DESCRIPTION
## Summary

- **Reconnect button actually works now.** `requestRebind()` is a no-op when the listener dies from a process kill (it only works after a voluntary `requestUnbind`). Replaced with a `PackageManager` component toggle that forces `rebindServices` via `ACTION_PACKAGE_CHANGED`.
- **Foreground service starts unconditionally.** It was skipped when accessibility was enabled, but OriginOS marks a killed accessibility service as "crashed" and never rebinds it — the process had no anchor at all. FGS channel is `IMPORTANCE_NONE` so there's still no status-bar icon.
- **App recovers after swipe-away.** Added `stopWithTask="false"`, `onTaskRemoved` restart alarm, and moved self-heal from `onCreate` to `onResume` so every foregrounding recovers the listener.
- **Onboarding calls out Associated startup.** Without vivo's "Associated startup" toggle, the OS blocks all restart mechanisms and only a reboot recovers. The setup screen now explains this explicitly.

## What was wrong

Two independent bugs:

1. `NotificationListenerService.requestRebind()` early-returns when the component isn't in the system's "snoozed" set. A process kill never snoozes it, so the system thinks the listener is still bound and the call does nothing — no amount of tapping Reconnect changes that.

2. `ensureForeground()` skipped the FGS when accessibility was on, assuming it anchored the process. On OriginOS, swiping the task kills the process, `AccessibilityManagerService` marks the service as crashed and never rebinds it, so the process had zero anchors and nothing restarted it.