### PR TITLE
Fix listener reconnect

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,9 +30,22 @@
 
         <!-- Posts / updates / ends OriginIsland SuperX cards. Special-use FGS so it can
              keep re-posting a live card (e.g. a ticking football score). -->
+        <!--
+            stopWithTask=false + START_STICKY are what get casting back after the app is swiped off
+            recents. OriginOS kills the whole app on that swipe (a separate :island process does NOT
+            survive it either — measured), so the recovery can't come from staying alive; it comes
+            from the system RESTARTING this foreground service afterwards, which respawns the
+            process and rebinds the notification listener with it.
+
+            That restart is gated on vivo's "Associated startup" toggle, which controls whether the
+            system may start this app at all. With it off, nothing recovers — not START_STICKY, not
+            the onTaskRemoved alarm, not the accessibility service — and only a reboot fixes it.
+            Onboarding calls that out explicitly; see OnboardingScreen.
+        -->
         <service
             android:name=".island.PlaygroundService"
-            android:foregroundServiceType="specialUse">
+            android:foregroundServiceType="specialUse"
+            android:stopWithTask="false">
             <property
                 android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
                 android:value="OriginIsland live update service" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,18 +30,10 @@
 
         <!-- Posts / updates / ends OriginIsland SuperX cards. Special-use FGS so it can
              keep re-posting a live card (e.g. a ticking football score). -->
-        <!--
-            stopWithTask=false + START_STICKY are what get casting back after the app is swiped off
-            recents. OriginOS kills the whole app on that swipe (a separate :island process does NOT
-            survive it either — measured), so the recovery can't come from staying alive; it comes
-            from the system RESTARTING this foreground service afterwards, which respawns the
-            process and rebinds the notification listener with it.
-
-            That restart is gated on vivo's "Associated startup" toggle, which controls whether the
-            system may start this app at all. With it off, nothing recovers — not START_STICKY, not
-            the onTaskRemoved alarm, not the accessibility service — and only a reboot fixes it.
-            Onboarding calls that out explicitly; see OnboardingScreen.
-        -->
+        <!-- stopWithTask=false + START_STICKY get casting back after a swipe-away: OriginOS kills
+             the process, so recovery comes from the system restarting this service, which rebinds
+             the listener with it. Gated on vivo's "Associated startup" — with that off nothing
+             recovers until a reboot, which is why onboarding pushes it. -->
         <service
             android:name=".island.PlaygroundService"
             android:foregroundServiceType="specialUse"

--- a/app/src/main/java/com/originisle/android/MainActivity.kt
+++ b/app/src/main/java/com/originisle/android/MainActivity.kt
@@ -1,9 +1,7 @@
 package com.originisle.android
 
-import android.content.ComponentName
 import android.content.Context
 import android.os.Bundle
-import android.service.notification.NotificationListenerService
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Column
@@ -46,15 +44,21 @@ class MainActivity : ComponentActivity() {
         intent?.getIntExtra("autofire_sample", -1)?.takeIf { it >= 0 }?.let {
             IslandSamples.all.getOrNull(it)?.post(this)
         }
+        setContent { OriginIsleTheme { Screen() } }
+    }
+
+    /**
+     * Heal a listener that died with the process (OriginOS kills it on swipe-away) every time the
+     * app comes to the foreground, not just on a cold start — otherwise a resume of an
+     * already-running task silently skips the recovery. [NotificationCastListener.forceRebind] is a
+     * no-op while the listener is connected, so this is cheap on the normal path.
+     */
+    override fun onResume() {
+        super.onResume()
         if (getSharedPreferences(PREFS_NAME, MODE_PRIVATE).getBoolean("cast_notifications", false)) {
             PlaygroundService.keepAlive(this)
-            runCatching {
-                NotificationListenerService.requestRebind(
-                    ComponentName(this, NotificationCastListener::class.java),
-                )
-            }
+            NotificationCastListener.forceRebind(this)
         }
-        setContent { OriginIsleTheme { Screen() } }
     }
 }
 

--- a/app/src/main/java/com/originisle/android/MainActivity.kt
+++ b/app/src/main/java/com/originisle/android/MainActivity.kt
@@ -48,10 +48,9 @@ class MainActivity : ComponentActivity() {
     }
 
     /**
-     * Heal a listener that died with the process (OriginOS kills it on swipe-away) every time the
-     * app comes to the foreground, not just on a cold start — otherwise a resume of an
-     * already-running task silently skips the recovery. [NotificationCastListener.forceRebind] is a
-     * no-op while the listener is connected, so this is cheap on the normal path.
+     * Heal a killed listener on every foregrounding, not just a cold start — resuming an
+     * already-running task would otherwise skip the recovery. Cheap: [forceRebind] no-ops while the
+     * listener is connected.
      */
     override fun onResume() {
         super.onResume()

--- a/app/src/main/java/com/originisle/android/OriginIsleApp.kt
+++ b/app/src/main/java/com/originisle/android/OriginIsleApp.kt
@@ -3,11 +3,15 @@ package com.originisle.android
 import android.app.Application
 import androidx.appcompat.app.AppCompatDelegate
 import com.originisle.android.island.OriginIslandBuilder
+import com.originisle.android.service.NotificationCastListener
 
 class OriginIsleApp : Application() {
     override fun onCreate() {
         super.onCreate()
         AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
         OriginIslandBuilder.grantScenes(this)
+        // Every process start, not just the UI's: a service restart is the likeliest way back in
+        // after the kill that could have left the component half-toggled.
+        NotificationCastListener.ensureEnabled(this)
     }
 }

--- a/app/src/main/java/com/originisle/android/island/PlaygroundService.kt
+++ b/app/src/main/java/com/originisle/android/island/PlaygroundService.kt
@@ -141,12 +141,15 @@ class PlaygroundService : Service() {
             .build()
         // Both calls can throw: the onTaskRemoved alarm starts this service from the background, and
         // that is only allowed while the app holds the battery-optimisation exemption (which
-        // onboarding lets the user skip). Failing to go foreground must not take the process down.
+        // onboarding lets the user skip).
         isForegroundActive = runCatching {
             startForeground(FGS_ID, n, android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE)
         }.recoverCatching {
             startForeground(FGS_ID, n)
         }.isSuccess
+        // Catching isn't enough to survive it: that alarm uses startForegroundService(), so the
+        // system kills us anyway unless we either go foreground or stop. Stop cleanly instead.
+        if (!isForegroundActive) stopSelf()
     }
 
     // --- posting -----------------------------------------------------------------
@@ -450,6 +453,9 @@ class PlaygroundService : Service() {
                 notificationManager.cancel(OriginIslandConstants.SUPERX_TAG, it)
                 notificationManager.cancel(it)
             }
+            // Clear the flag with the teardown, or a start arriving before we're destroyed sees a
+            // stale "already foreground" and skips ensureForeground(), leaving the process unanchored.
+            isForegroundActive = false
             stopForeground(STOP_FOREGROUND_REMOVE)
             stopSelf()
         }

--- a/app/src/main/java/com/originisle/android/island/PlaygroundService.kt
+++ b/app/src/main/java/com/originisle/android/island/PlaygroundService.kt
@@ -83,6 +83,14 @@ class PlaygroundService : Service() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        // A null intent is a START_STICKY relaunch and ACTION_KEEPALIVE is the alarm/UI anchor
+        // request: both only mean "stay up", which is pointless once casting is off. Explicit card
+        // actions still work with it off, so the sample buttons are unaffected.
+        if ((intent == null || intent.action == ACTION_KEEPALIVE) && !isCastingEnabled()) {
+            cancelRestartAlarm()
+            stopSelf()
+            return START_NOT_STICKY
+        }
         ensureForeground()
         try {
             when (intent?.action) {
@@ -105,17 +113,42 @@ class PlaygroundService : Service() {
      */
     override fun onTaskRemoved(rootIntent: Intent?) {
         super.onTaskRemoved(rootIntent)
+        // With casting off there is nothing to come back for, and arming the alarm would revive the
+        // service a second after the user swiped it away — for good, since nothing else stops it.
+        if (!isCastingEnabled()) {
+            cancelRestartAlarm()
+            stopSelf()
+            return
+        }
         runCatching { ensureForeground() }
         runCatching {
-            val restart = PendingIntent.getForegroundService(
-                this,
-                RESTART_REQUEST,
-                Intent(this, PlaygroundService::class.java).setAction(ACTION_KEEPALIVE),
-                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
-            )
-            getSystemService(AlarmManager::class.java)?.set(
-                AlarmManager.RTC_WAKEUP, System.currentTimeMillis() + 1000L, restart,
-            )
+            restartAlarmIntent(PendingIntent.FLAG_UPDATE_CURRENT)?.let { restart ->
+                getSystemService(AlarmManager::class.java)?.set(
+                    AlarmManager.RTC_WAKEUP, System.currentTimeMillis() + 1000L, restart,
+                )
+            }
+        }
+    }
+
+    /** Matches the listener's own gate — either card source keeps the service worth running. */
+    private fun isCastingEnabled(): Boolean = getSharedPreferences(PREFS_NAME, 0).let {
+        it.getBoolean("cast_notifications", false) || it.getBoolean("cast_media_sessions", false)
+    }
+
+    /** [flags] picks between arming (FLAG_UPDATE_CURRENT) and looking one up (FLAG_NO_CREATE). */
+    private fun restartAlarmIntent(flags: Int): PendingIntent? = PendingIntent.getForegroundService(
+        this,
+        RESTART_REQUEST,
+        Intent(this, PlaygroundService::class.java).setAction(ACTION_KEEPALIVE),
+        flags or PendingIntent.FLAG_IMMUTABLE,
+    )
+
+    private fun cancelRestartAlarm() {
+        runCatching {
+            restartAlarmIntent(PendingIntent.FLAG_NO_CREATE)?.let {
+                getSystemService(AlarmManager::class.java)?.cancel(it)
+                it.cancel()
+            }
         }
     }
 
@@ -438,6 +471,8 @@ class PlaygroundService : Service() {
     }
 
     private fun stopEverything() {
+        // An explicit stop must not be undone by an alarm a previous swipe left armed.
+        cancelRestartAlarm()
         autoDismissTasks.values.forEach { mainHandler.removeCallbacks(it) }
         autoDismissTasks.clear()
         val hadScenes = originScenes.isNotEmpty()

--- a/app/src/main/java/com/originisle/android/island/PlaygroundService.kt
+++ b/app/src/main/java/com/originisle/android/island/PlaygroundService.kt
@@ -1,24 +1,22 @@
 package com.originisle.android.island
 
+import android.app.AlarmManager
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.Service
-import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.graphics.drawable.Icon
 import android.os.Handler
 import android.os.IBinder
 import android.os.Looper
-import android.provider.Settings
 import android.util.Log
 import android.widget.RemoteViews
 import androidx.core.app.NotificationCompat
 import com.originisle.android.R
 import com.originisle.android.service.IconCache
-import com.originisle.android.service.KeepAliveAccessibilityService
 import com.originisle.android.ui.PREFS_NAME
 import java.util.concurrent.ConcurrentHashMap
 
@@ -56,6 +54,9 @@ class PlaygroundService : Service() {
 
         const val ORIGIN_CHANNEL_ID = "originisle_island_hi"
         const val FGS_ID = 9999
+
+        /** PendingIntent request code for the [onTaskRemoved] restart alarm. */
+        private const val RESTART_REQUEST = 7001
     }
 
     private lateinit var notificationManager: NotificationManager
@@ -97,18 +98,55 @@ class PlaygroundService : Service() {
         return START_STICKY
     }
 
+    /**
+     * Swiping the task away on OriginOS kills the whole process — the notification listener with it.
+     * START_STICKY is not enough on its own there (the service simply never came back), so re-arm
+     * two ways: make sure the FGS is up, and leave an alarm behind that restarts this service a
+     * second later if the process dies anyway.
+     *
+     * The alarm survives the kill because a swipe is a plain process kill, not a force-stop —
+     * verified with `dumpsys package`, which still reports `stopped=false` afterwards. (A real
+     * force-stop sets that flag and cancels alarms, and nothing an app does can escape it.)
+     * [PendingIntent.getForegroundService] is what the alarm fires; starting an FGS from the
+     * background is allowed here because the app is on the battery-optimisation allowlist, which
+     * onboarding already asks for.
+     */
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        super.onTaskRemoved(rootIntent)
+        runCatching { ensureForeground() }
+        runCatching {
+            val restart = PendingIntent.getForegroundService(
+                this,
+                RESTART_REQUEST,
+                Intent(this, PlaygroundService::class.java).setAction(ACTION_KEEPALIVE),
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            )
+            getSystemService(AlarmManager::class.java)?.set(
+                AlarmManager.RTC_WAKEUP, System.currentTimeMillis() + 1000L, restart,
+            )
+        }
+    }
+
     private fun ensureForeground() {
         if (isForegroundActive) return
-        // If the keep-alive AccessibilityService is enabled, it anchors the process for us — so we
-        // DON'T start a foreground service, and skipping it removes the status-bar icon that OriginOS
-        // force-shows for any FGS.
+        // The FGS now starts UNCONDITIONALLY. It used to be skipped whenever the keep-alive
+        // AccessibilityService was enabled, on the theory that accessibility alone anchors the
+        // process — but that premise is wrong, and it was the reason casting died for good on
+        // swipe-away. Measured on an X200 Pro (OriginOS): swiping the task away kills the process,
+        // and `dumpsys accessibility` then reports
         //
-        // IMPORTANT: we only SKIP starting the FGS here; we must NEVER tear down an already-running
-        // FGS the instant accessibility connects. Doing that left the process with no anchor for a
-        // moment, OriginOS killed it, and the kill disconnected (disabled) the accessibility service.
-        // So the FGS just isn't (re)started once accessibility is on — the icon clears on the next
-        // process start, and the process always keeps an anchor.
-        if (isKeepAliveAccessibilityEnabled()) return
+        //     Enabled services:{{…/KeepAliveAccessibilityService}}
+        //     Crashed services:{{…/KeepAliveAccessibilityService}}
+        //
+        // i.e. AccessibilityManagerService sees the binding die, marks the service CRASHED, and
+        // never rebinds it. It stays "enabled" in Settings.Secure while being completely dead, so
+        // the process had no anchor at all, nothing restarted it, and only a reboot (which rebinds
+        // every enabled accessibility service from scratch) brought casting back.
+        //
+        // The status-bar icon this skip was avoiding is already handled a different way: CHANNEL_ID
+        // is created at IMPORTANCE_NONE (blocked), which suppresses the FGS notification outright —
+        // see createNotificationChannel. So running the FGS costs nothing visually and buys the one
+        // anchor the system actually honours across task removal.
         createNotificationChannel(CHANNEL_ID)
         val n = NotificationCompat.Builder(this, CHANNEL_ID)
             .setContentTitle("Origin Isle")
@@ -435,15 +473,6 @@ class PlaygroundService : Service() {
             stopSelf()
         }
         if (hadScenes) mainHandler.postDelayed({ finish() }, 350L) else finish()
-    }
-
-    /** True when the user has enabled the keep-alive AccessibilityService (no FGS icon needed then). */
-    private fun isKeepAliveAccessibilityEnabled(): Boolean {
-        val flat = Settings.Secure.getString(
-            contentResolver, Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES,
-        ) ?: return false
-        val target = ComponentName(this, KeepAliveAccessibilityService::class.java)
-        return flat.split(':').any { ComponentName.unflattenFromString(it) == target }
     }
 
     private fun createNotificationChannel(channelId: String) {

--- a/app/src/main/java/com/originisle/android/island/PlaygroundService.kt
+++ b/app/src/main/java/com/originisle/android/island/PlaygroundService.kt
@@ -99,17 +99,9 @@ class PlaygroundService : Service() {
     }
 
     /**
-     * Swiping the task away on OriginOS kills the whole process — the notification listener with it.
-     * START_STICKY is not enough on its own there (the service simply never came back), so re-arm
-     * two ways: make sure the FGS is up, and leave an alarm behind that restarts this service a
-     * second later if the process dies anyway.
-     *
-     * The alarm survives the kill because a swipe is a plain process kill, not a force-stop —
-     * verified with `dumpsys package`, which still reports `stopped=false` afterwards. (A real
-     * force-stop sets that flag and cancels alarms, and nothing an app does can escape it.)
-     * [PendingIntent.getForegroundService] is what the alarm fires; starting an FGS from the
-     * background is allowed here because the app is on the battery-optimisation allowlist, which
-     * onboarding already asks for.
+     * START_STICKY alone didn't bring the service back on OriginOS, so also leave an alarm behind
+     * that restarts it a second later. The alarm survives because a swipe is a plain process kill,
+     * not a force-stop (which would cancel it, and which nothing can escape).
      */
     override fun onTaskRemoved(rootIntent: Intent?) {
         super.onTaskRemoved(rootIntent)
@@ -129,24 +121,11 @@ class PlaygroundService : Service() {
 
     private fun ensureForeground() {
         if (isForegroundActive) return
-        // The FGS now starts UNCONDITIONALLY. It used to be skipped whenever the keep-alive
-        // AccessibilityService was enabled, on the theory that accessibility alone anchors the
-        // process — but that premise is wrong, and it was the reason casting died for good on
-        // swipe-away. Measured on an X200 Pro (OriginOS): swiping the task away kills the process,
-        // and `dumpsys accessibility` then reports
-        //
-        //     Enabled services:{{…/KeepAliveAccessibilityService}}
-        //     Crashed services:{{…/KeepAliveAccessibilityService}}
-        //
-        // i.e. AccessibilityManagerService sees the binding die, marks the service CRASHED, and
-        // never rebinds it. It stays "enabled" in Settings.Secure while being completely dead, so
-        // the process had no anchor at all, nothing restarted it, and only a reboot (which rebinds
-        // every enabled accessibility service from scratch) brought casting back.
-        //
-        // The status-bar icon this skip was avoiding is already handled a different way: CHANNEL_ID
-        // is created at IMPORTANCE_NONE (blocked), which suppresses the FGS notification outright —
-        // see createNotificationChannel. So running the FGS costs nothing visually and buys the one
-        // anchor the system actually honours across task removal.
+        // Starts UNCONDITIONALLY. This used to be skipped when the keep-alive AccessibilityService
+        // was enabled, assuming it anchored the process — but a swipe-away kill makes
+        // AccessibilityManagerService mark the service CRASHED and never rebind it, so it stayed
+        // "enabled" while completely dead and nothing restarted us until a reboot. The status-bar
+        // icon that skip was avoiding is handled instead by CHANNEL_ID being IMPORTANCE_NONE.
         createNotificationChannel(CHANNEL_ID)
         val n = NotificationCompat.Builder(this, CHANNEL_ID)
             .setContentTitle("Origin Isle")
@@ -160,12 +139,14 @@ class PlaygroundService : Service() {
             .setSilent(true)
             .setOngoing(true)
             .build()
-        try {
+        // Both calls can throw: the onTaskRemoved alarm starts this service from the background, and
+        // that is only allowed while the app holds the battery-optimisation exemption (which
+        // onboarding lets the user skip). Failing to go foreground must not take the process down.
+        isForegroundActive = runCatching {
             startForeground(FGS_ID, n, android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE)
-        } catch (_: Exception) {
+        }.recoverCatching {
             startForeground(FGS_ID, n)
-        }
-        isForegroundActive = true
+        }.isSuccess
     }
 
     // --- posting -----------------------------------------------------------------

--- a/app/src/main/java/com/originisle/android/service/KeepAliveAccessibilityService.kt
+++ b/app/src/main/java/com/originisle/android/service/KeepAliveAccessibilityService.kt
@@ -1,8 +1,6 @@
 package com.originisle.android.service
 
 import android.accessibilityservice.AccessibilityService
-import android.content.ComponentName
-import android.service.notification.NotificationListenerService
 import android.view.accessibility.AccessibilityEvent
 import com.originisle.android.island.OriginIslandBuilder
 
@@ -21,11 +19,10 @@ class KeepAliveAccessibilityService : AccessibilityService() {
 
     override fun onServiceConnected() {
         super.onServiceConnected()
-        runCatching {
-            NotificationListenerService.requestRebind(
-                ComponentName(this, NotificationCastListener::class.java),
-            )
-        }
+        // This fires when the system (re)starts our process, which is exactly the moment the
+        // notification listener needs recovering after a swipe-away kill. A plain requestRebind is
+        // a no-op in that case — see [NotificationCastListener.forceRebind].
+        runCatching { NotificationCastListener.forceRebind(this) }
         runCatching { OriginIslandBuilder.grantScenes(this) }
     }
 

--- a/app/src/main/java/com/originisle/android/service/KeepAliveAccessibilityService.kt
+++ b/app/src/main/java/com/originisle/android/service/KeepAliveAccessibilityService.kt
@@ -19,9 +19,8 @@ class KeepAliveAccessibilityService : AccessibilityService() {
 
     override fun onServiceConnected() {
         super.onServiceConnected()
-        // This fires when the system (re)starts our process, which is exactly the moment the
-        // notification listener needs recovering after a swipe-away kill. A plain requestRebind is
-        // a no-op in that case — see [NotificationCastListener.forceRebind].
+        // Fires when the system (re)starts our process — exactly when the listener needs recovering
+        // after a swipe-away kill, where a plain requestRebind is a no-op (see [forceRebind]).
         runCatching { NotificationCastListener.forceRebind(this) }
         runCatching { OriginIslandBuilder.grantScenes(this) }
     }

--- a/app/src/main/java/com/originisle/android/service/NotificationCastListener.kt
+++ b/app/src/main/java/com/originisle/android/service/NotificationCastListener.kt
@@ -3,8 +3,10 @@ package com.originisle.android.service
 import android.app.Notification
 import android.app.NotificationManager
 import android.content.ComponentName
+import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
+import android.content.pm.PackageManager
 import android.graphics.drawable.Icon
 import android.media.session.MediaController
 import android.media.session.MediaSession
@@ -16,6 +18,7 @@ import android.service.notification.NotificationListenerService.Ranking
 import android.service.notification.StatusBarNotification
 import android.util.Log
 import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
 import com.originisle.android.cards.GenericCard
 import com.originisle.android.cards.MediaCard
 import com.originisle.android.cards.NavigationCard
@@ -43,6 +46,9 @@ import java.util.concurrent.ConcurrentHashMap
  */
 class NotificationCastListener : NotificationListenerService() {
 
+    /** Outcome of [forceRebind], so callers can tell the user something truthful. */
+    enum class RebindResult { REBINDING, ALREADY_CONNECTED, NO_ACCESS, FAILED }
+
     companion object {
         /** The bound listener instance, or null if the service isn't connected. */
         @Volatile
@@ -54,8 +60,74 @@ class NotificationCastListener : NotificationListenerService() {
         @Volatile
         var lastEventAt: Long = 0L
 
+        /**
+         * Force the system to re-bind this listener after the process was killed (OriginOS kills it
+         * on swipe-away), and report whether a rebind could even be attempted.
+         *
+         * [NotificationListenerService.requestRebind] alone is NOT enough, and this is the whole
+         * reason the Reconnect button did nothing. It lands in `NotificationManagerService`
+         * -> `ManagedServices.setComponentState(component, userId, enabled = true)`, which starts
+         * with an early return when the requested state already matches the tracked one:
+         *
+         *     boolean previous = !mSnoozing...contains(component);
+         *     if (previous == enabled) return;
+         *
+         * A component is only in that "snoozing" set after an explicit [requestUnbind]. When the
+         * listener instead dies with a force-stopped process, it was never snoozed — so the system
+         * still believes it is bound, `previous == enabled` holds, and `requestRebind` returns
+         * having done literally nothing. No amount of tapping the button changes that; only a
+         * reboot (which rebuilds the bindings from scratch) did.
+         *
+         * Toggling the component's enabled state is what actually moves the system: each
+         * `setComponentEnabledSetting` fires `ACTION_PACKAGE_CHANGED`, whose receiver in
+         * `NotificationManagerService` calls `mListeners.onPackagesChanged(removing = false, …)`
+         * -> `rebindServices()`, and that rebinds every approved-but-unbound listener. The grant
+         * itself lives in `Settings.Secure.enabled_notification_listeners` keyed by component name
+         * and is untouched by this, so access is not lost. `DONT_KILL_APP` keeps our own process
+         * (and the island's foreground service) up across the toggle.
+         */
+        fun forceRebind(context: Context): RebindResult {
+            val component = ComponentName(context.applicationContext, NotificationCastListener::class.java)
+            if (!NotificationManagerCompat.getEnabledListenerPackages(context)
+                    .contains(context.packageName)
+            ) {
+                return RebindResult.NO_ACCESS
+            }
+            if (instance != null) return RebindResult.ALREADY_CONNECTED
+            // The rebind is asynchronous (it waits on a package broadcast), so a burst of callers —
+            // onResume firing repeatedly while the listener is still down — must not keep tearing
+            // down a binding that is already on its way up.
+            val now = System.currentTimeMillis()
+            if (now - lastRebindAt < REBIND_THROTTLE_MS) return RebindResult.REBINDING
+            lastRebindAt = now
+
+            val pm = context.applicationContext.packageManager
+            val toggled = runCatching {
+                pm.setComponentEnabledSetting(
+                    component,
+                    PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+                    PackageManager.DONT_KILL_APP,
+                )
+                pm.setComponentEnabledSetting(
+                    component,
+                    PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+                    PackageManager.DONT_KILL_APP,
+                )
+            }.isSuccess
+            // Belt and braces: after the toggle the component IS considered unbound, so this call is
+            // no longer a no-op and can shortcut the wait for the package broadcast to land.
+            runCatching { requestRebind(component) }
+            return if (toggled) RebindResult.REBINDING else RebindResult.FAILED
+        }
+
         private const val PREFS = "experimental_prefs"
         private const val TAG = "NotificationCast"
+
+        /** Minimum gap between component toggles in [forceRebind]. */
+        private const val REBIND_THROTTLE_MS = 10_000L
+
+        @Volatile
+        private var lastRebindAt = 0L
 
         /** Framework/system packages whose notifications are noise on the island. */
         private val SYSTEM_PKGS = setOf(
@@ -195,6 +267,11 @@ class NotificationCastListener : NotificationListenerService() {
         if (instance === this) instance = null
         connectedAt = 0L
         pollHandler.removeCallbacks(pollRunnable)
+        // A system-initiated unbind DOES leave the component snoozed, so here — unlike from the
+        // Reconnect button — a plain requestRebind is the documented, working way back (see
+        // [forceRebind] for why it is a no-op in the process-kill case). Self-heals the transient
+        // disconnects without the user having to open the app at all.
+        runCatching { requestRebind(ComponentName(this, NotificationCastListener::class.java)) }
     }
 
     /**

--- a/app/src/main/java/com/originisle/android/service/NotificationCastListener.kt
+++ b/app/src/main/java/com/originisle/android/service/NotificationCastListener.kt
@@ -64,27 +64,13 @@ class NotificationCastListener : NotificationListenerService() {
          * Force the system to re-bind this listener after the process was killed (OriginOS kills it
          * on swipe-away), and report whether a rebind could even be attempted.
          *
-         * [NotificationListenerService.requestRebind] alone is NOT enough, and this is the whole
-         * reason the Reconnect button did nothing. It lands in `NotificationManagerService`
-         * -> `ManagedServices.setComponentState(component, userId, enabled = true)`, which starts
-         * with an early return when the requested state already matches the tracked one:
-         *
-         *     boolean previous = !mSnoozing...contains(component);
-         *     if (previous == enabled) return;
-         *
-         * A component is only in that "snoozing" set after an explicit [requestUnbind]. When the
-         * listener instead dies with a force-stopped process, it was never snoozed — so the system
-         * still believes it is bound, `previous == enabled` holds, and `requestRebind` returns
-         * having done literally nothing. No amount of tapping the button changes that; only a
-         * reboot (which rebuilds the bindings from scratch) did.
-         *
-         * Toggling the component's enabled state is what actually moves the system: each
-         * `setComponentEnabledSetting` fires `ACTION_PACKAGE_CHANGED`, whose receiver in
-         * `NotificationManagerService` calls `mListeners.onPackagesChanged(removing = false, …)`
-         * -> `rebindServices()`, and that rebinds every approved-but-unbound listener. The grant
-         * itself lives in `Settings.Secure.enabled_notification_listeners` keyed by component name
-         * and is untouched by this, so access is not lost. `DONT_KILL_APP` keeps our own process
-         * (and the island's foreground service) up across the toggle.
+         * [NotificationListenerService.requestRebind] alone is NOT enough — the whole reason the
+         * Reconnect button did nothing. It early-returns unless the component was explicitly
+         * snoozed by [requestUnbind], and a process kill never snoozes it, so the system still
+         * believes we're bound. Toggling the component's enabled state instead fires
+         * ACTION_PACKAGE_CHANGED, which makes NotificationManagerService rebind every
+         * approved-but-unbound listener. The grant lives in Settings.Secure keyed by component and
+         * survives the toggle; DONT_KILL_APP keeps our own process up across it.
          */
         fun forceRebind(context: Context): RebindResult {
             val component = ComponentName(context.applicationContext, NotificationCastListener::class.java)
@@ -99,7 +85,6 @@ class NotificationCastListener : NotificationListenerService() {
             // down a binding that is already on its way up.
             val now = System.currentTimeMillis()
             if (now - lastRebindAt < REBIND_THROTTLE_MS) return RebindResult.REBINDING
-            lastRebindAt = now
 
             val pm = context.applicationContext.packageManager
             val toggled = runCatching {
@@ -114,10 +99,14 @@ class NotificationCastListener : NotificationListenerService() {
                     PackageManager.DONT_KILL_APP,
                 )
             }.isSuccess
-            // Belt and braces: after the toggle the component IS considered unbound, so this call is
-            // no longer a no-op and can shortcut the wait for the package broadcast to land.
+            // Only arm the throttle once the toggle actually landed, so a failure doesn't leave the
+            // next 10s of taps reporting "rebinding" when nothing is.
+            if (!toggled) return RebindResult.FAILED
+            lastRebindAt = now
+            // After the toggle the component IS considered unbound, so this call is no longer a
+            // no-op and can shortcut the wait for the package broadcast to land.
             runCatching { requestRebind(component) }
-            return if (toggled) RebindResult.REBINDING else RebindResult.FAILED
+            return RebindResult.REBINDING
         }
 
         private const val PREFS = "experimental_prefs"
@@ -267,10 +256,8 @@ class NotificationCastListener : NotificationListenerService() {
         if (instance === this) instance = null
         connectedAt = 0L
         pollHandler.removeCallbacks(pollRunnable)
-        // A system-initiated unbind DOES leave the component snoozed, so here — unlike from the
-        // Reconnect button — a plain requestRebind is the documented, working way back (see
-        // [forceRebind] for why it is a no-op in the process-kill case). Self-heals the transient
-        // disconnects without the user having to open the app at all.
+        // A system-initiated unbind DOES snooze the component, so unlike the process-kill case a
+        // plain requestRebind works here (see [forceRebind]). Self-heals transient disconnects.
         runCatching { requestRebind(ComponentName(this, NotificationCastListener::class.java)) }
     }
 

--- a/app/src/main/java/com/originisle/android/service/NotificationCastListener.kt
+++ b/app/src/main/java/com/originisle/android/service/NotificationCastListener.kt
@@ -86,13 +86,17 @@ class NotificationCastListener : NotificationListenerService() {
             val now = System.currentTimeMillis()
             if (now - lastRebindAt < REBIND_THROTTLE_MS) return RebindResult.REBINDING
 
+            // Separate runCatching per step: the re-enable must be attempted even if the disable
+            // threw. See [ensureEnabled] for why being left disabled is unrecoverable.
             val pm = context.applicationContext.packageManager
-            val toggled = runCatching {
+            val disabled = runCatching {
                 pm.setComponentEnabledSetting(
                     component,
                     PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
                     PackageManager.DONT_KILL_APP,
                 )
+            }.isSuccess
+            val enabled = runCatching {
                 pm.setComponentEnabledSetting(
                     component,
                     PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
@@ -101,12 +105,36 @@ class NotificationCastListener : NotificationListenerService() {
             }.isSuccess
             // Only arm the throttle once the toggle actually landed, so a failure doesn't leave the
             // next 10s of taps reporting "rebinding" when nothing is.
-            if (!toggled) return RebindResult.FAILED
+            if (!disabled || !enabled) return RebindResult.FAILED
             lastRebindAt = now
             // After the toggle the component IS considered unbound, so this call is no longer a
             // no-op and can shortcut the wait for the package broadcast to land.
             runCatching { requestRebind(component) }
             return RebindResult.REBINDING
+        }
+
+        /**
+         * Undo a [forceRebind] that only got halfway — the process can die between its two calls,
+         * and DONT_KILL_APP only stops PackageManager from killing us, not OriginOS. A component
+         * left DISABLED persists across reboots and never binds again, while the grant it's checked
+         * against lives in Settings.Secure and still reads as granted, so the UI would show a
+         * healthy listener forever. Called on every process start.
+         */
+        fun ensureEnabled(context: Context) {
+            val pm = context.applicationContext.packageManager
+            val component = ComponentName(context.applicationContext, NotificationCastListener::class.java)
+            runCatching {
+                if (pm.getComponentEnabledSetting(component) ==
+                    PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+                ) {
+                    Log.w(TAG, "listener component was left disabled by a partial rebind — re-enabling")
+                    pm.setComponentEnabledSetting(
+                        component,
+                        PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+                        PackageManager.DONT_KILL_APP,
+                    )
+                }
+            }
         }
 
         private const val PREFS = "experimental_prefs"

--- a/app/src/main/java/com/originisle/android/ui/CastTab.kt
+++ b/app/src/main/java/com/originisle/android/ui/CastTab.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -65,6 +66,11 @@ fun CastTab(context: Context, prefs: SharedPreferences, onRedoSetup: () -> Unit)
     val listenerOk = remember(tick.intValue) { isListenerEnabled(context) }
     val batteryOk = remember(tick.intValue) { isBatteryUnrestricted(context) }
     var setupExpanded by remember { mutableStateOf(!listenerOk || !batteryOk) }
+    // Re-open on resume when something has broken since, or the card stays collapsed over a status
+    // line saying access is gone. Only ever expands — collapsing stays the user's call.
+    LaunchedEffect(listenerOk, batteryOk) {
+        if (!listenerOk || !batteryOk) setupExpanded = true
+    }
     var samplesExpanded by remember { mutableStateOf(false) }
     var updateStatus by remember { mutableStateOf<String?>(null) }
     val coroutineScope = rememberCoroutineScope()
@@ -169,9 +175,10 @@ fun CastTab(context: Context, prefs: SharedPreferences, onRedoSetup: () -> Unit)
                         )
                         OutlinedButton(
                             onClick = {
-                                openAutoStartSettings(context)
-                                autoStartAck = true
-                                prefs.edit().putBoolean("onboarding_autostart_ack", true).apply()
+                                if (openAutoStartSettings(context)) {
+                                    autoStartAck = true
+                                    prefs.edit().putBoolean("onboarding_autostart_ack", true).apply()
+                                }
                             },
                             modifier = Modifier.fillMaxWidth(),
                         ) { Text("Autostart + Associated startup") }

--- a/app/src/main/java/com/originisle/android/ui/CastTab.kt
+++ b/app/src/main/java/com/originisle/android/ui/CastTab.kt
@@ -270,15 +270,13 @@ private fun recastAll(context: Context) {
     PlaygroundService.keepAlive(context)
     val listener = NotificationCastListener.instance
     if (listener == null) {
-        runCatching {
-            android.service.notification.NotificationListenerService.requestRebind(
-                android.content.ComponentName(context, NotificationCastListener::class.java),
-            )
+        val message = when (NotificationCastListener.forceRebind(context)) {
+            NotificationCastListener.RebindResult.NO_ACCESS ->
+                "Notification access isn't granted — turn it on in Settings, then tap again."
+            else ->
+                "Listener not connected — reconnecting now. Give it a few seconds, then tap again."
         }
-        android.widget.Toast.makeText(
-            context, "Listener not connected yet — grant notification access, reboot app, then tap again.",
-            android.widget.Toast.LENGTH_LONG,
-        ).show()
+        android.widget.Toast.makeText(context, message, android.widget.Toast.LENGTH_LONG).show()
         return
     }
     val count = listener.recastAll()

--- a/app/src/main/java/com/originisle/android/ui/CastTab.kt
+++ b/app/src/main/java/com/originisle/android/ui/CastTab.kt
@@ -50,19 +50,20 @@ fun CastTab(context: Context, prefs: SharedPreferences, onRedoSetup: () -> Unit)
     var ignoreSilent by remember { mutableStateOf(prefs.getBoolean("cast_ignore_silent", true)) }
     var lockscreenLiveCard by remember { mutableStateOf(prefs.getBoolean("cast_lockscreen_live_card", false)) }
     var autoDismissSec by remember { mutableStateOf(prefs.getInt("cast_auto_dismiss_seconds", 0)) }
-    val listenerText = remember { listenerStatusText(context) }
-    val batteryText = remember { batteryStatusText(context) }
-    val accessibilityText = remember { accessibilityStatusText(context) }
-    // vivo exposes no way to read the auto-start / "Associated startup" toggles, so all we can track
-    // is whether the user has been sent to that screen — same ack flag the onboarding row writes.
+    val tick = rememberResumeTick()
+    val listenerText = remember(tick.intValue) { listenerStatusText(context) }
+    val batteryText = remember(tick.intValue) { batteryStatusText(context) }
+    val accessibilityText = remember(tick.intValue) { accessibilityStatusText(context) }
+    // Neither vivo toggle is readable, so all we can track is whether the user has been sent to that
+    // screen — the same ack flag the onboarding row writes.
     var autoStartAck by remember { mutableStateOf(prefs.getBoolean("onboarding_autostart_ack", false)) }
     val autoStartText = autoStartStatusText(autoStartAck)
 
     // Setup only needs attention again if something actually broke (OriginOS revoking notification
     // access or re-restricting battery is a known failure mode) — otherwise it stays collapsed to a
     // one-line status so it's not the first thing in the way on every open.
-    val listenerOk = remember { isListenerEnabled(context) }
-    val batteryOk = remember { isBatteryUnrestricted(context) }
+    val listenerOk = remember(tick.intValue) { isListenerEnabled(context) }
+    val batteryOk = remember(tick.intValue) { isBatteryUnrestricted(context) }
     var setupExpanded by remember { mutableStateOf(!listenerOk || !batteryOk) }
     var samplesExpanded by remember { mutableStateOf(false) }
     var updateStatus by remember { mutableStateOf<String?>(null) }
@@ -173,11 +174,9 @@ fun CastTab(context: Context, prefs: SharedPreferences, onRedoSetup: () -> Unit)
                                 prefs.edit().putBoolean("onboarding_autostart_ack", true).apply()
                             },
                             modifier = Modifier.fillMaxWidth(),
-                        ) { Text("Auto-start + Associated startup") }
+                        ) { Text("Autostart + Associated startup") }
                         Text(
-                            "Turn BOTH on, especially \"Associated startup\" — it's what lets the system " +
-                                "restart Origin Isle. With it off, closing the app from recents kills " +
-                                "casting until you reboot the phone.",
+                            "Turn BOTH on, or closing the app from recents kills casting until you reboot.",
                             style = MaterialTheme.typography.bodySmall,
                         )
                         Text(listenerText, style = MaterialTheme.typography.bodySmall)

--- a/app/src/main/java/com/originisle/android/ui/CastTab.kt
+++ b/app/src/main/java/com/originisle/android/ui/CastTab.kt
@@ -53,6 +53,10 @@ fun CastTab(context: Context, prefs: SharedPreferences, onRedoSetup: () -> Unit)
     val listenerText = remember { listenerStatusText(context) }
     val batteryText = remember { batteryStatusText(context) }
     val accessibilityText = remember { accessibilityStatusText(context) }
+    // vivo exposes no way to read the auto-start / "Associated startup" toggles, so all we can track
+    // is whether the user has been sent to that screen — same ack flag the onboarding row writes.
+    var autoStartAck by remember { mutableStateOf(prefs.getBoolean("onboarding_autostart_ack", false)) }
+    val autoStartText = autoStartStatusText(autoStartAck)
 
     // Setup only needs attention again if something actually broke (OriginOS revoking notification
     // access or re-restricting battery is a known failure mode) — otherwise it stays collapsed to a
@@ -162,14 +166,24 @@ fun CastTab(context: Context, prefs: SharedPreferences, onRedoSetup: () -> Unit)
                                 "with NO status-bar icon. It reads nothing.",
                             style = MaterialTheme.typography.bodySmall,
                         )
+                        OutlinedButton(
+                            onClick = {
+                                openAutoStartSettings(context)
+                                autoStartAck = true
+                                prefs.edit().putBoolean("onboarding_autostart_ack", true).apply()
+                            },
+                            modifier = Modifier.fillMaxWidth(),
+                        ) { Text("Auto-start + Associated startup") }
+                        Text(
+                            "Turn BOTH on, especially \"Associated startup\" — it's what lets the system " +
+                                "restart Origin Isle. With it off, closing the app from recents kills " +
+                                "casting until you reboot the phone.",
+                            style = MaterialTheme.typography.bodySmall,
+                        )
                         Text(listenerText, style = MaterialTheme.typography.bodySmall)
                         Text(batteryText, style = MaterialTheme.typography.bodySmall)
                         Text(accessibilityText, style = MaterialTheme.typography.bodySmall)
-                        Text(
-                            "OriginOS also has a separate \"Auto-start\" allow-list in Settings → Battery. " +
-                                "Enable Origin Isle there too, or the caster is killed when the screen is off.",
-                            style = MaterialTheme.typography.bodySmall,
-                        )
+                        Text(autoStartText, style = MaterialTheme.typography.bodySmall)
                         OutlinedButton(onClick = onRedoSetup, modifier = Modifier.fillMaxWidth()) {
                             Text("Redo first-run setup")
                         }

--- a/app/src/main/java/com/originisle/android/ui/LogTab.kt
+++ b/app/src/main/java/com/originisle/android/ui/LogTab.kt
@@ -122,13 +122,18 @@ fun LogTab(context: Context) {
 }
 
 private fun reconnectListener(context: Context) {
-    runCatching {
-        android.service.notification.NotificationListenerService.requestRebind(
-            android.content.ComponentName(context, NotificationCastListener::class.java),
-        )
-    }
     PlaygroundService.keepAlive(context)
-    android.widget.Toast.makeText(context, "Rebinding listener…", android.widget.Toast.LENGTH_SHORT).show()
+    val message = when (NotificationCastListener.forceRebind(context)) {
+        NotificationCastListener.RebindResult.REBINDING ->
+            "Rebinding listener… give it a few seconds."
+        NotificationCastListener.RebindResult.ALREADY_CONNECTED ->
+            "Listener is already connected."
+        NotificationCastListener.RebindResult.NO_ACCESS ->
+            "Notification access isn't granted — turn it on in Settings first."
+        NotificationCastListener.RebindResult.FAILED ->
+            "Couldn't rebind. Reboot, or toggle notification access off and on."
+    }
+    android.widget.Toast.makeText(context, message, android.widget.Toast.LENGTH_LONG).show()
 }
 
 private fun clockText(ts: Long): String =

--- a/app/src/main/java/com/originisle/android/ui/OnboardingScreen.kt
+++ b/app/src/main/java/com/originisle/android/ui/OnboardingScreen.kt
@@ -95,8 +95,9 @@ fun OnboardingScreen(context: Context, prefs: SharedPreferences, onDone: () -> U
             }
             item {
                 OnboardingRow(
-                    title = "Keep-alive (no status-bar icon)",
-                    description = "Runs in the background invisibly.",
+                    title = "Keep-alive",
+                    description = "Reconnects casting when OriginOS restarts the app, instead of " +
+                        "waiting for you to open it.",
                     granted = accessOk,
                     mandatory = false,
                 ) { context.startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS)) }
@@ -117,9 +118,12 @@ fun OnboardingScreen(context: Context, prefs: SharedPreferences, onDone: () -> U
                     granted = autoStartAck,
                     mandatory = false,
                 ) {
-                    openAutoStartSettings(context)
-                    autoStartAck = true
-                    prefs.edit().putBoolean("onboarding_autostart_ack", true).apply()
+                    // Only ack if a screen actually opened — a ✓ the user never saw is worse than
+                    // no ✓ for the one setting that decides whether casting survives a swipe-away.
+                    if (openAutoStartSettings(context)) {
+                        autoStartAck = true
+                        prefs.edit().putBoolean("onboarding_autostart_ack", true).apply()
+                    }
                 }
             }
             item {

--- a/app/src/main/java/com/originisle/android/ui/OnboardingScreen.kt
+++ b/app/src/main/java/com/originisle/android/ui/OnboardingScreen.kt
@@ -6,7 +6,6 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Build
 import android.provider.Settings
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
@@ -22,56 +21,40 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
 
 /**
  * First-run gate: walks through every authorization the app needs before letting the user into the
  * main tabs. Only notification access is mandatory to continue; the rest are strongly recommended
  * (battery, keep-alive, auto-start) and can be granted later from the Cast tab's "Redo setup" button.
  *
- * The auto-start row matters more than its "recommended" status suggests: OriginOS's "Associated
- * startup" toggle governs whether the SYSTEM is allowed to start this app. With it off, nothing can
- * bring casting back after the app is swiped off recents — not START_STICKY, not the restart alarm,
- * not the accessibility service — and only a reboot recovers. Measured on an X200 Pro.
- * Every row re-checks its status when the user returns from Settings (via [Lifecycle.Event.ON_RESUME]).
+ * The startup row matters more than "recommended" suggests: with "Associated startup" off, nothing
+ * brings casting back after a swipe-away — not START_STICKY, not the restart alarm, not the
+ * accessibility service — and only a reboot recovers.
  */
 @Composable
 fun OnboardingScreen(context: Context, prefs: SharedPreferences, onDone: () -> Unit) {
-    val activity = LocalContext.current as? ComponentActivity
-    var tick by remember { mutableIntStateOf(0) }
-    DisposableEffect(activity) {
-        if (activity == null) return@DisposableEffect onDispose { }
-        val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_RESUME) tick++
-        }
-        activity.lifecycle.addObserver(observer)
-        onDispose { activity.lifecycle.removeObserver(observer) }
-    }
+    val tick = rememberResumeTick()
 
     val notifPermission = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission(),
-    ) { tick++ }
+    ) { tick.intValue++ }
 
-    val notifGranted = remember(tick) { isListenerEnabled(context) }
-    val postGranted = remember(tick) {
+    val notifGranted = remember(tick.intValue) { isListenerEnabled(context) }
+    val postGranted = remember(tick.intValue) {
         Build.VERSION.SDK_INT < 33 ||
             androidx.core.content.ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) ==
             android.content.pm.PackageManager.PERMISSION_GRANTED
     }
-    val batteryOk = remember(tick) { isBatteryUnrestricted(context) }
-    val accessOk = remember(tick) { isAccessibilityEnabled(context) }
+    val batteryOk = remember(tick.intValue) { isBatteryUnrestricted(context) }
+    val accessOk = remember(tick.intValue) { isAccessibilityEnabled(context) }
     var autoStartAck by remember {
         mutableStateOf(prefs.getBoolean("onboarding_autostart_ack", false))
     }
@@ -128,11 +111,9 @@ fun OnboardingScreen(context: Context, prefs: SharedPreferences, onDone: () -> U
             }
             item {
                 OnboardingRow(
-                    title = "Auto-start + Associated startup",
-                    description = "Turn BOTH on, especially \"Associated startup\". Without it OriginOS " +
-                        "forbids the system from restarting Origin Isle, so closing the app from recents " +
-                        "kills casting until you reboot the phone. vivo doesn't let apps check this, so " +
-                        "it's on you to confirm it's on.",
+                    title = "Autostart + Associated startup",
+                    description = "Turn BOTH on. Without them, closing the app from recents kills " +
+                        "casting until you reboot.",
                     granted = autoStartAck,
                     mandatory = false,
                 ) {

--- a/app/src/main/java/com/originisle/android/ui/OnboardingScreen.kt
+++ b/app/src/main/java/com/originisle/android/ui/OnboardingScreen.kt
@@ -40,6 +40,11 @@ import androidx.lifecycle.LifecycleEventObserver
  * First-run gate: walks through every authorization the app needs before letting the user into the
  * main tabs. Only notification access is mandatory to continue; the rest are strongly recommended
  * (battery, keep-alive, auto-start) and can be granted later from the Cast tab's "Redo setup" button.
+ *
+ * The auto-start row matters more than its "recommended" status suggests: OriginOS's "Associated
+ * startup" toggle governs whether the SYSTEM is allowed to start this app. With it off, nothing can
+ * bring casting back after the app is swiped off recents — not START_STICKY, not the restart alarm,
+ * not the accessibility service — and only a reboot recovers. Measured on an X200 Pro.
  * Every row re-checks its status when the user returns from Settings (via [Lifecycle.Event.ON_RESUME]).
  */
 @Composable
@@ -123,8 +128,11 @@ fun OnboardingScreen(context: Context, prefs: SharedPreferences, onDone: () -> U
             }
             item {
                 OnboardingRow(
-                    title = "OriginOS auto-start",
-                    description = "vivo can't be checked automatically.",
+                    title = "Auto-start + Associated startup",
+                    description = "Turn BOTH on, especially \"Associated startup\". Without it OriginOS " +
+                        "forbids the system from restarting Origin Isle, so closing the app from recents " +
+                        "kills casting until you reboot the phone. vivo doesn't let apps check this, so " +
+                        "it's on you to confirm it's on.",
                     granted = autoStartAck,
                     mandatory = false,
                 ) {

--- a/app/src/main/java/com/originisle/android/ui/StatusHelpers.kt
+++ b/app/src/main/java/com/originisle/android/ui/StatusHelpers.kt
@@ -35,6 +35,17 @@ fun accessibilityStatusText(context: Context): String =
 fun batteryStatusText(context: Context): String =
     if (isBatteryUnrestricted(context)) "Battery: unrestricted ✓" else "Battery: restricted (tap above)"
 
+/**
+ * vivo doesn't expose the auto-start / "Associated startup" state to apps, so [acknowledged] is only
+ * a record that the user was sent to that screen — never proof the toggles are actually on.
+ */
+fun autoStartStatusText(acknowledged: Boolean): String =
+    if (acknowledged) {
+        "Auto-start + Associated startup: opened ✓ (vivo won't let us verify — check it's still on)"
+    } else {
+        "Auto-start + Associated startup: not confirmed (tap above)"
+    }
+
 fun requestIgnoreBattery(context: Context) {
     if (isBatteryUnrestricted(context)) return
     runCatching {
@@ -54,24 +65,33 @@ fun requestIgnoreBattery(context: Context) {
 }
 
 /**
- * OriginOS keeps a separate "auto-start" allow-list (Settings → Battery → Auto-start) that can't be
- * queried programmatically. Try the known vivo manager screen; fall back to the app's own details
- * page so the user can find the equivalent setting themselves.
+ * OriginOS keeps "Autostart" and "Associated startup" together on a per-app "Device management"
+ * page, neither of them readable by apps — see [autoStartStatusText].
+ *
+ * Deep-link straight to that page instead of dumping the user in the global background-start-up
+ * list to hunt for Origin Isle. It's SoftPermissionDetailActivity, which takes its target from a
+ * "packagename" string extra and calls finish() immediately if that extra is missing or names a
+ * package it can't resolve (read off PermissionManager.apk and confirmed on an X200 Pro). Since the
+ * package we pass is our own, it's always resolvable. The remaining fallbacks cover vivo builds
+ * that don't ship the same activity, where startActivity throws instead.
  */
 fun openAutoStartSettings(context: Context) {
-    runCatching {
-        context.startActivity(
-            Intent().setClassName(
+    val targets = listOf(
+        Intent("permission.intent.action.softPermissionDetail")
+            .setClassName(
                 "com.vivo.permissionmanager",
-                "com.vivo.permissionmanager.activity.BgStartUpManagerActivity",
-            ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
-        )
-    }.onFailure {
-        runCatching {
-            context.startActivity(
-                Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS, Uri.parse("package:${context.packageName}"))
-                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                "com.vivo.permissionmanager.activity.SoftPermissionDetailActivity",
             )
-        }
+            .putExtra("packagename", context.packageName),
+        Intent().setClassName(
+            "com.vivo.permissionmanager",
+            "com.vivo.permissionmanager.activity.BgStartUpManagerActivity",
+        ),
+        Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS, Uri.parse("package:${context.packageName}")),
+    )
+    targets.firstOrNull { intent ->
+        runCatching {
+            context.startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+        }.isSuccess
     }
 }

--- a/app/src/main/java/com/originisle/android/ui/StatusHelpers.kt
+++ b/app/src/main/java/com/originisle/android/ui/StatusHelpers.kt
@@ -58,8 +58,15 @@ fun isBatteryUnrestricted(context: Context): Boolean {
 fun listenerStatusText(context: Context): String =
     if (isListenerEnabled(context)) "Notification access: granted ✓" else "Notification access: NOT granted"
 
+// Not about the status-bar icon any more: the foreground service now always starts (its icon is
+// hidden by the IMPORTANCE_NONE channel instead), so what this service still buys is the rebind it
+// fires from onServiceConnected whenever OriginOS restarts the process.
 fun accessibilityStatusText(context: Context): String =
-    if (isAccessibilityEnabled(context)) "Keep-alive: on ✓ (no status-bar icon)" else "Keep-alive: off (status-bar icon shows)"
+    if (isAccessibilityEnabled(context)) {
+        "Keep-alive: on ✓ (reconnects casting after a kill)"
+    } else {
+        "Keep-alive: off (slower to recover after a kill)"
+    }
 
 fun batteryStatusText(context: Context): String =
     if (isBatteryUnrestricted(context)) "Battery: unrestricted ✓" else "Battery: restricted (tap above)"
@@ -95,8 +102,12 @@ fun requestIgnoreBattery(context: Context) {
  * startup", rather than the global list the user would have to hunt through. The activity takes its
  * target from a "packagename" extra and silently finishes if that's missing or unresolvable. The
  * fallbacks cover vivo builds without it, where startActivity throws instead.
+ *
+ * Returns whether anything was launched. Only [Settings.ACTION_APPLICATION_DETAILS_SETTINGS] is
+ * guaranteed to exist, so false means the device has no reachable screen at all — but true is not
+ * proof the user saw the right one, hence the hedged wording in [autoStartStatusText].
  */
-fun openAutoStartSettings(context: Context) {
+fun openAutoStartSettings(context: Context): Boolean {
     val targets = listOf(
         Intent("permission.intent.action.softPermissionDetail")
             .setClassName(
@@ -110,7 +121,7 @@ fun openAutoStartSettings(context: Context) {
         ),
         Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS, Uri.parse("package:${context.packageName}")),
     )
-    targets.firstOrNull { intent ->
+    return targets.any { intent ->
         runCatching {
             context.startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
         }.isSuccess

--- a/app/src/main/java/com/originisle/android/ui/StatusHelpers.kt
+++ b/app/src/main/java/com/originisle/android/ui/StatusHelpers.kt
@@ -5,10 +5,39 @@ import android.content.Intent
 import android.net.Uri
 import android.os.PowerManager
 import android.provider.Settings
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.MutableIntState
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
 import androidx.core.app.NotificationManagerCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import com.originisle.android.service.KeepAliveAccessibilityService
 
 /** Shared permission/status checks used by both [OnboardingScreen] and the Cast tab. */
+
+/**
+ * A counter that bumps on every ON_RESUME. None of these permissions can be observed, so use
+ * `intValue` as a `remember` key to re-check them when the user comes back from Settings. Callers
+ * can bump it themselves for grants that don't leave the activity, e.g. a permission dialog.
+ */
+@Composable
+fun rememberResumeTick(): MutableIntState {
+    val activity = LocalContext.current as? ComponentActivity
+    val tick = remember { mutableIntStateOf(0) }
+    DisposableEffect(activity) {
+        if (activity == null) return@DisposableEffect onDispose { }
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) tick.intValue++
+        }
+        activity.lifecycle.addObserver(observer)
+        onDispose { activity.lifecycle.removeObserver(observer) }
+    }
+    return tick
+}
 
 fun isListenerEnabled(context: Context): Boolean =
     NotificationManagerCompat.getEnabledListenerPackages(context).contains(context.packageName)
@@ -35,15 +64,12 @@ fun accessibilityStatusText(context: Context): String =
 fun batteryStatusText(context: Context): String =
     if (isBatteryUnrestricted(context)) "Battery: unrestricted ✓" else "Battery: restricted (tap above)"
 
-/**
- * vivo doesn't expose the auto-start / "Associated startup" state to apps, so [acknowledged] is only
- * a record that the user was sent to that screen — never proof the toggles are actually on.
- */
+/** [acknowledged] only records that the user was sent to the screen, never that the toggles are on. */
 fun autoStartStatusText(acknowledged: Boolean): String =
     if (acknowledged) {
-        "Auto-start + Associated startup: opened ✓ (vivo won't let us verify — check it's still on)"
+        "Associated startup: opened ✓ (can't be verified — check it's still on)"
     } else {
-        "Auto-start + Associated startup: not confirmed (tap above)"
+        "Associated startup: not confirmed (tap above)"
     }
 
 fun requestIgnoreBattery(context: Context) {
@@ -65,15 +91,10 @@ fun requestIgnoreBattery(context: Context) {
 }
 
 /**
- * OriginOS keeps "Autostart" and "Associated startup" together on a per-app "Device management"
- * page, neither of them readable by apps — see [autoStartStatusText].
- *
- * Deep-link straight to that page instead of dumping the user in the global background-start-up
- * list to hunt for Origin Isle. It's SoftPermissionDetailActivity, which takes its target from a
- * "packagename" string extra and calls finish() immediately if that extra is missing or names a
- * package it can't resolve (read off PermissionManager.apk and confirmed on an X200 Pro). Since the
- * package we pass is our own, it's always resolvable. The remaining fallbacks cover vivo builds
- * that don't ship the same activity, where startActivity throws instead.
+ * Deep-link to the per-app "Device management" page holding both "Autostart" and "Associated
+ * startup", rather than the global list the user would have to hunt through. The activity takes its
+ * target from a "packagename" extra and silently finishes if that's missing or unresolvable. The
+ * fallbacks cover vivo builds without it, where startActivity throws instead.
  */
 fun openAutoStartSettings(context: Context) {
     val targets = listOf(


### PR DESCRIPTION
## Summary

Fixes notification casting dying permanently after swiping the app off recents on OriginOS (vivo). Two root causes:

### `requestRebind()` was a silent no-op after a process kill

`NotificationListenerService.requestRebind()` only works when the listener was explicitly unbound via `requestUnbind()` — it removes the component from a "snoozing" set. A process kill never snoozes the component, so the system still believes it's bound, `requestRebind` early-returns, and the Reconnect button does nothing. Only a reboot rebuilt the bindings.

**Fix:** Replace `requestRebind` with `forceRebind()`, which toggles the component's enabled state off and back on via `PackageManager.setComponentEnabledSetting`. Each toggle fires `ACTION_PACKAGE_CHANGED`, making `NotificationManagerService` call `rebindServices()` and reconnect every approved-but-unbound listener. The notification access grant (in `Settings.Secure`) is untouched; `DONT_KILL_APP` keeps the process alive.

### Foreground service was skipped when accessibility was enabled

`ensureForeground()` returned early when `KeepAliveAccessibilityService` was enabled, assuming accessibility anchored the process. On OriginOS, a swipe-away kill makes `AccessibilityManagerService` mark the service as CRASHED without rebinding it — it stays "enabled" in Settings while completely dead, leaving no process anchor and no restart path until a reboot.

**Fix:** The FGS now starts unconditionally. The status-bar icon concern is handled by the notification channel being `IMPORTANCE_NONE`.

### Additional changes

- **`onTaskRemoved` restart alarm** — belt-and-braces fallback that restarts the service 1s after a swipe-away, in case `START_STICKY` alone doesn't bring it back (it didn't on OriginOS)
- **`stopWithTask="false"`** in the manifest so the system knows to restart the FGS
- **Self-heal moved to `onResume`** — every foregrounding triggers recovery, not just cold starts
- **`onListenerDisconnected` self-heal** — calls `requestRebind` for system-initiated unbinds (which *do* snooze the component), so transient disconnects recover without the user opening the app
- **"Autostart + Associated startup" button** in the Cast tab's setup section, deep-linked to vivo's per-app `SoftPermissionDetailActivity` instead of the global list
- **`rememberResumeTick()`** — shared composable so the Cast tab's permission rows re-check on resume instead of going stale after a trip to Settings
- **`startForeground` crash guard** — both the 3-arg and 2-arg calls are now wrapped, so a background FGS start failure on the alarm path doesn't crash the process
- **Rebind throttle fix** — only armed after a successful toggle, so a failure doesn't leave 10s of taps reporting "rebinding"